### PR TITLE
Omit final comma in HTML format list

### DIFF
--- a/gisserver/templates/gisserver/wfs/feature_type.html
+++ b/gisserver/templates/gisserver/wfs/feature_type.html
@@ -6,7 +6,7 @@
   <p>
     {% trans "Formats" %}:
     {% for output_format in wfs_output_formats %}
-      <a href="?SERVICE=WFS&VERSION={{ version }}&REQUEST=GetFeature&TYPENAMES={{ feature_type.name }}&OUTPUTFORMAT={{ output_format.identifier }}">{{ output_format.title|default:output_format }}</a>,
+      <a href="?SERVICE=WFS&VERSION={{ version }}&REQUEST=GetFeature&TYPENAMES={{ feature_type.name }}&OUTPUTFORMAT={{ output_format.identifier }}">{{ output_format.title|default:output_format }}</a>{% if not forloop.last %},{% endif %}
     {% endfor %}
   </p>
 {% endif %}{% endblock %}


### PR DESCRIPTION
Bijv. nu:

> Formats: GML, GML 3.2.1, GeoJSON, CSV,

Wordt:

> Formats: GML, GML 3.2.1, GeoJSON, CSV