### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,15 @@ repos:
     hooks:
       - id: black
         #language_version: python3.6
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.0
     hooks:
       - id: flake8
         exclude: migrations/
         additional_dependencies:
-          - flake8-blind-except == 0.1.1
-          - flake8-debugger == 3.2.1
-          - flake8-colors == 0.1.6
+          - flake8-bugbear == 21.4.3
+          - flake8-debugger == 4.0.0
+          - flake8-colors == 0.1.9
           - flake8-raise == 0.0.5
 
 #  - repo: https://github.com/prettier/prettier

--- a/gisserver/queries/stored.py
+++ b/gisserver/queries/stored.py
@@ -72,7 +72,7 @@ class StoredQuery(QueryExpression):
     def extract_parameters(cls, KVP) -> Dict[str, str]:
         """Extract the arguments from the key-value-pair (=HTTP GET) request."""
         args = {}
-        for name, xsd_type in cls.meta.parameters.items():
+        for name, _xsd_type in cls.meta.parameters.items():
             try:
                 args[name] = KVP[name]
             except KeyError:


### PR DESCRIPTION
* Ran `pre-commit autoupdate` to pull the latest hook version
* Updated the URL for flake8 for its move from GitLab to GitHub (see: https://twitter.com/codewithanthony/status/1378746934928699396)
* Replaced `flake8-blind-except` with `flake8-bugbear`. `flake8-blind-except` was throwing some false positives on re-raised exceptions. `flake8-bugbear`'s rule B001 covers blindly caught exceptions more thoroughly, plus it covers many other best practices.
* UPdated all other flake8 `additional_dependencies` to their latest versions.