### PR TITLE
Drop universal wheel declaration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[wheel]
-# create "py2.py3-none-any.whl" package
-universal = 1
-
 [flake8]
 exclude=.git,
         **/migrations/*,


### PR DESCRIPTION
Python 2 is no longer supported so distributed wheels should not be marked as supporting it.