### PR TITLE
Support Django 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,25 +30,46 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-django22
     - python: 3.6
-      env: TOXENV=py36-django22 GISSERVER_USE_DB_RENDERING=0
+      env: TOXENV=py36-django30
+    - python: 3.6
+      env: TOXENV=py36-django31
+    - python: 3.6
+      env: TOXENV=py36-django32
     # Python 3.7
     - python: 3.7
       env: TOXENV=py37-django22
     - python: 3.7
       env: TOXENV=py37-django30
     - python: 3.7
-      env: TOXENV=py37-django30 GISSERVER_USE_DB_RENDERING=0
+      env: TOXENV=py37-django31
+    - python: 3.7
+      env: TOXENV=py37-django32
     # Python 3.8
     - python: 3.8
       env: TOXENV=py38-django22
     - python: 3.8
       env: TOXENV=py38-django30
     - python: 3.8
-      env: TOXENV=py38-django30 GISSERVER_USE_DB_RENDERING=0
-    - python: 3.8
       env: TOXENV=py38-django31
     - python: 3.8
-      env: TOXENV=py38-django31 GISSERVER_USE_DB_RENDERING=0
+      env: TOXENV=py38-django32
+    # Python 3.9
+    - python: 3.9
+      env: TOXENV=py39-django22
+    - python: 3.9
+      env: TOXENV=py39-django22 GISSERVER_USE_DB_RENDERING=0
+    - python: 3.9
+      env: TOXENV=py39-django30
+    - python: 3.9
+      env: TOXENV=py39-django30 GISSERVER_USE_DB_RENDERING=0
+    - python: 3.9
+      env: TOXENV=py39-django31
+    - python: 3.9
+      env: TOXENV=py39-django31 GISSERVER_USE_DB_RENDERING=0
+    - python: 3.9
+      env: TOXENV=py39-django32
+    - python: 3.9
+      env: TOXENV=py39-django32 GISSERVER_USE_DB_RENDERING=0
 
 cache:
   directories:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Support Django 3.2.
+
 # 2020-12-22 (1.1.2)
 
 * Fixed double ``>`` sign in ``<Filter xml..>>`` code when namespaces were auto-corrected.

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Application Frameworks",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,4 @@
+import django
 from environ import Env
 
 env = Env()
@@ -9,6 +10,9 @@ DATABASES = {
         engine="django.contrib.gis.db.backends.postgis",
     )
 }
+
+if django.VERSION >= (3, 2):
+    DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 GISSERVER_USE_DB_RENDERING = env.bool("GISSERVER_USE_DB_RENDERING", default=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py36-django22, py{37,38}-django{22,30,31}
+envlist =
+    py36-django{22,30,31,32}
+    py37-django{22,30,31,32}
+    py38-django{22,30,31,32}
+    py39-django{22,30,31,32}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -7,6 +11,7 @@ deps =
     django22: Django~=2.2
     django30: Django~=3.0
     django31: Django~=3.1
+    django32: Django~=3.2
 passenv = DATABASE_URL, GISSERVER_USE_DB_RENDERING
 extras = test
 


### PR DESCRIPTION
* Add to both tox and travis grids. This included completing the grid of all Python versions versus Django versions for older Django versions. I moved the `GISSERVER_USE_DB_RENDERING` tests to only Python 3.9. I think these would be better embedded in the normal test suite with `@override_settings` to run the few tests that depend on the setting being `False` rather than whole extra test runs.
* Add the extra `DEFAULT_AUTO_FIELD` setting for Django 3.2.
* Add changelog note and PyPI classifier.