### PR TITLE
Add GEOJSON outputformat for WFS

### DIFF
--- a/gisserver/operations/wfs20.py
+++ b/gisserver/operations/wfs20.py
@@ -439,6 +439,9 @@ class GetFeature(BaseWFSGetDataMethod):
             renderer_class=output.csv_renderer,
             title="CSV",
         ),
+        # Output format that is redundant, however it is required
+        # to make ESRI ArcGIS online accept the WFS.
+        OutputFormat("GEOJSON", renderer_class=output.geojson_renderer),
         # OutputFormat("shapezip"),
         # OutputFormat("application/zip"),
     ]


### PR DESCRIPTION
Although geojson is already specified as an outputformat, this is not understood by ESRI ArcGIS Online.

Adding it like this, seems to be accepted by ArcGIS Online.