### PR TITLE
Fix type assetion on `XsdElement` and update pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@
 # Supported hooks: https://pre-commit.com/hooks.html
 # Running "make format" fixes most issues for you
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
       - id: black
         #language_version: python3.6

--- a/gisserver/types.py
+++ b/gisserver/types.py
@@ -527,7 +527,9 @@ class XsdElement(XsdNode):
         return self.max_occurs and (
             self.max_occurs == "unbounded"
             or self.max_occurs > 1
-            or isinstance(self.source, ArrayField)  # needed for ArrayField(size=1)
+            or isinstance(
+                self.source, type(ArrayField)
+            )  # needed for ArrayField(size=1)
         )
 
 


### PR DESCRIPTION
I've run into this issue when trying to set up an API: 
```
File "/usr/local/lib/python3.9/site-packages/gisserver/types.py", line 530, in is_many
    or isinstance(self.source, ArrayField)  # needed for ArrayField(size=1)
TypeError: isinstance() arg 2 must be a type or tuple of types
```
And created this PR with a fix.

Also, the pre-commit hook was failing because the version of `black` being used wasn't compatible with the `click` version installed (see [this for more details](https://github.com/psf/black/issues/2964)). 