### PR TITLE
Don't abuse SyntaxError for user input validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-01-11 (1.2.5)
+
+* CRS parsing no longer raises SyntaxErrors.
+
 # 2022-11-01 (1.2.4)
 
 * Fixed type assertion when `django.contrib.postgres` was not installed.

--- a/gisserver/__init__.py
+++ b/gisserver/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.4"  # follows PEP440
+__version__ = "1.2.5"  # follows PEP440

--- a/gisserver/geometries.py
+++ b/gisserver/geometries.py
@@ -174,7 +174,7 @@ class CRS:
             try:
                 srid = int(crsid)
             except ValueError:
-                raise SyntaxError(
+                raise ExternalValueError(
                     f"CRS URI [{urn}] should contain a numeric SRID value."
                 ) from None
         elif authority == "OGC":
@@ -214,7 +214,7 @@ class CRS:
                 try:
                     srid = int(crsid)
                 except ValueError:
-                    raise SyntaxError(
+                    raise ExternalValueError(
                         f"CRS URI [{uri}] should contain a numeric SRID value."
                     ) from None
 


### PR DESCRIPTION
SyntaxError is for errors in Python programs.