### PR TITLE
Workaround for FME

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
-# Upcoming release
+# 2023-06-07 (1.2.6)
 
+* Workaround for FME doing a DescribeFeatureType with the wrong outputformat.
 * Dropped support for Django versions < 3.2 and Python < 3.9.
 * Minor optimizations.
 

--- a/gisserver/__init__.py
+++ b/gisserver/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.5"  # follows PEP440
+__version__ = "1.2.6"  # follows PEP440

--- a/gisserver/operations/base.py
+++ b/gisserver/operations/base.py
@@ -258,14 +258,16 @@ class WFSMethod:
 
     def _parse_output_format(self, value) -> OutputFormat:
         """Select the proper OutputFormat object based on the input value"""
-        value = value.replace(" ", "+")  # allow application/gml+xml on the KVP.
-        try:
-            return next(o for o in self.output_formats if o.matches(value))
-        except StopIteration:
-            raise InvalidParameterValue(
-                "outputformat",
-                f"'{value}' is not a permitted output format for this operation.",
-            ) from None
+        # The str.replace is here to "allow application/gml+xml on the KVP",
+        # but I'm not sure what that comment was supposed to mean.
+        for v in [value, value.replace(" ", "+")]:
+            for o in self.output_formats:
+                if o.matches(v):
+                    return o
+        raise InvalidParameterValue(
+            "outputformat",
+            f"'{value}' is not a permitted output format for this operation.",
+        ) from None
 
     def _parse_namespaces(self, value) -> dict[str, str]:
         """Parse the namespaces definition.

--- a/gisserver/operations/wfs20.py
+++ b/gisserver/operations/wfs20.py
@@ -141,6 +141,11 @@ class DescribeFeatureType(WFSTypeNamesMethod):
 
     output_formats = [
         OutputFormat("XMLSCHEMA", renderer_class=output.XMLSchemaRenderer),
+        # At least one version of FME seems to sends a DescribeFeatureType
+        # request with this output format. Do what mapserver does and just
+        # send it XML Schema.
+        OutputFormat("application/gml+xml; version=3.2",
+                     renderer_class=output.XMLSchemaRenderer)
         # OutputFormat("text/xml", subtype="gml/3.1.1"),
     ]
 

--- a/tests/gisserver/views/test_describefeaturetype.py
+++ b/tests/gisserver/views/test_describefeaturetype.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import pytest
 from lxml import etree
 
@@ -198,6 +200,15 @@ class TestDescribeFeatureType:
 
 </schema>""",  # noqa: E501
         )
+
+    def test_describe_outputformat(self, client):
+        """Test workaround for FME's outputformat."""
+        gml32 = urllib.parse.quote("application/gml+xml; version=3.2")
+        response = client.get(
+            f"/v1/wfs/?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=restaurant&outputformat={gml32}"
+        )
+        content = response.content.decode()
+        assert response.status_code == 200, content
 
     def test_empty_typenames(self, client):
         """Prove that missing arguments are handled"""


### PR DESCRIPTION
From what I can tell, the response to `DescribeFeatureType` is always an XML Schema. But FME sends such requests with a GML `outputformat`. Do what mapserver does and ignore the `outputformat`.

Ref: https://opengeospatial.github.io/e-learning/wfs/text/operations.html