### PR TITLE
1.2.7: Accept GML OUTPUTFORMAT with version, as sent by FME

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-06-08 (1.2.7)
+
+* WFS endpoints now accept a GML version number in their OUTPUTFORMAT.
+
 # 2023-06-07 (1.2.6)
 
 * Workaround for FME doing a DescribeFeatureType with the wrong outputformat.

--- a/gisserver/__init__.py
+++ b/gisserver/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.6"  # follows PEP440
+__version__ = "1.2.7"  # follows PEP440

--- a/gisserver/operations/base.py
+++ b/gisserver/operations/base.py
@@ -158,6 +158,10 @@ class OutputFormat:
 
     def matches(self, value):
         """Test whether the 'value' is matched by this object."""
+        if self.content_type == "application/gml+xml":
+            # Allow "application/gml+xml; version=3.2" as sent by FME.
+            # TODO rewrite this matching code in a clean way.
+            value = value.split("; ", 1)[0]
         return self.content_type == value or self.subtype == value
 
     @property

--- a/gisserver/operations/wfs20.py
+++ b/gisserver/operations/wfs20.py
@@ -45,7 +45,15 @@ RE_SAFE_FILENAME = re.compile(r"\A[A-Za-z0-9]+[A-Za-z0-9.]*")  # no dot at the s
 class GetCapabilities(WFSMethod):
     """ "This operation returns map features, and available operations this WFS server supports."""
 
-    output_formats = [OutputFormat("text/xml")]
+    output_formats = [
+        OutputFormat(
+            "application/gml+xml",
+            version="3.2",
+            renderer_class=output.gml32_value_renderer,
+            title="GML",
+        ),
+        OutputFormat("text/xml"),
+    ]
     xml_template_name = "get_capabilities.xml"
 
     def get_parameters(self):
@@ -144,8 +152,11 @@ class DescribeFeatureType(WFSTypeNamesMethod):
         # At least one version of FME seems to sends a DescribeFeatureType
         # request with this output format. Do what mapserver does and just
         # send it XML Schema.
-        OutputFormat("application/gml+xml; version=3.2",
-                     renderer_class=output.XMLSchemaRenderer)
+        OutputFormat(
+            "application/gml+xml",
+            version="3.2",
+            renderer_class=output.XMLSchemaRenderer,
+        )
         # OutputFormat("text/xml", subtype="gml/3.1.1"),
     ]
 
@@ -462,6 +473,12 @@ class GetPropertyValue(BaseWFSGetDataMethod):
     """
 
     output_formats = [
+        OutputFormat(
+            "application/gml+xml",
+            version="3.2",
+            renderer_class=output.gml32_value_renderer,
+            title="GML",
+        ),
         OutputFormat(
             "text/xml", subtype="gml/3.2", renderer_class=output.gml32_value_renderer
         ),

--- a/tests/gisserver/views/test_getcapabilities.py
+++ b/tests/gisserver/views/test_getcapabilities.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 import pytest
 from lxml import etree
 
@@ -14,8 +16,9 @@ class TestGetCapabilities:
 
     def test_get(self, client, restaurant, coordinates):
         """Prove that the happy flow works"""
+        gml32 = quote_plus("application/gml+xml; version=3.2")
         response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetCapabilities&ACCEPTVERSIONS=2.0.0"
+            "/v1/wfs/?SERVICE=WFS&REQUEST=GetCapabilities&ACCEPTVERSIONS=2.0.0&OUTPUTFORMAT={gml32}"
         )
         content = response.content.decode()
         assert response["content-type"] == "text/xml; charset=utf-8", content

--- a/tests/gisserver/views/test_getpropertyvalue.py
+++ b/tests/gisserver/views/test_getpropertyvalue.py
@@ -31,9 +31,10 @@ class TestGetPropertyValue:
     )
     def test_get(self, client, restaurant, bad_restaurant, xpath):
         """Prove that the happy flow works"""
+        gml32 = quote_plus("application/gml+xml; version=3.2")
         response = client.get(
             "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
-            f"&VALUEREFERENCE={xpath}"
+            f"&VALUEREFERENCE={xpath}&OUTPUTFORMAT={gml32}"
         )
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content


### PR DESCRIPTION
This time, I'm not sure if we or FME are violating the OGC standard. But we may need a cleaner way of matching these things.