### PR TITLE
replace utc import with datetime one

### DIFF
--- a/gisserver/output/csv.py
+++ b/gisserver/output/csv.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import csv
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.conf import settings
 from django.db import models
-from django.utils.timezone import utc
 
 from gisserver import conf
 from gisserver.db import (
@@ -137,7 +136,7 @@ class CSVRenderer(OutputRenderer):
                 # Array field
                 append(",".join(map(str, value)))
             elif isinstance(value, datetime):
-                append(str(value.astimezone(utc)))
+                append(str(value.astimezone(timezone.utc)))
             else:
                 append(value)
         return values

--- a/gisserver/output/geojson.py
+++ b/gisserver/output/geojson.py
@@ -1,5 +1,5 @@
 """Output rendering logic for GeoJSON."""
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import cast
 
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.contrib.gis.db.models.functions import AsGeoJSON
 from django.db import models
 from django.utils.functional import Promise
-from django.utils.timezone import utc
 
 from gisserver import conf
 from gisserver.db import get_db_geometry_target
@@ -147,7 +146,7 @@ class GeoJsonRenderer(OutputRenderer):
 
     def _format_geojson_value(self, value):
         if isinstance(value, datetime):
-            return value.astimezone(utc)
+            return value.astimezone(timezone.utc)
         elif isinstance(value, models.Model):
             # ForeignKey, not defined as complex type.
             return str(value)

--- a/gisserver/output/gml32.py
+++ b/gisserver/output/gml32.py
@@ -7,14 +7,13 @@ from __future__ import annotations
 
 import itertools
 import re
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from html import escape
 from typing import cast
 
 from django.contrib.gis import geos
 from django.db import models
 from django.http import HttpResponse
-from django.utils.timezone import utc
 
 from gisserver.db import (
     AsGML,
@@ -306,7 +305,7 @@ class GML32Renderer(OutputRenderer):
             # Expanded foreign relation / dictionary
             return self.render_xml_complex_type(feature_type, xsd_element, value)
         elif isinstance(value, datetime):
-            value = value.astimezone(utc).isoformat()
+            value = value.astimezone(timezone.utc).isoformat()
         elif isinstance(value, (date, time)):
             value = value.isoformat()
         elif isinstance(value, bool):

--- a/gisserver/output/results.py
+++ b/gisserver/output/results.py
@@ -13,7 +13,9 @@ from typing import Iterable
 import django
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.timezone import now, utc
+from django.utils.timezone import now
+
+from datetime import timezone
 
 from gisserver.features import FeatureType
 from gisserver.geometries import BoundingBox
@@ -218,7 +220,7 @@ class FeatureCollection:
         self.next = next
         self.previous = previous
         self.date = now()
-        self.timestamp = self.date.astimezone(utc).isoformat()
+        self.timestamp = self.date.astimezone(timezone.utc).isoformat()
 
     def get_bounding_box(self) -> BoundingBox:
         """Determine bounding box of all items."""

--- a/tests/test_gisserver/models.py
+++ b/tests/test_gisserver/models.py
@@ -4,11 +4,11 @@ from datetime import datetime, time
 from django.contrib.gis.db.models import PointField
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.utils.timezone import utc
 
+from datetime import timezone
 
 def current_datetime():
-    return datetime(2020, 4, 5, 12, 11, 10, 0, tzinfo=utc)
+    return datetime(2020, 4, 5, 12, 11, 10, 0, tzinfo=timezone.utc)
 
 
 class City(models.Model):


### PR DESCRIPTION
In Django 5 the `The django.utils.timezone.utc alias to datetime.timezone.utc is removed.` see: https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0

This replaces all uses of `django.utils.timezone.utc` with `datetime.timezone.utc` in this repo, to keep it compatible with Django 5.