### PR TITLE
Add support for python 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,6 +46,8 @@ jobs:
             python: "3.11"
           - django: "5.1"
             python: "3.12"
+          - django: "5.1.3"
+            python: "3.13"
 
     steps:
       - name: Install GeoDjango dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
     python: python3.9
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -17,20 +17,20 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args:
         - --py39-plus
         - --keep-runtime-typing
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.20.0"
+    rev: "1.22.2"
     hooks:
       - id: django-upgrade
         args:
           - --target-version=3.2
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.2
+    rev: v0.8.6
     hooks:
       - id: ruff
         args:
@@ -39,6 +39,6 @@ repos:
         - --config=pyproject.toml
         - --exit-non-zero-on-fix
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update \
 # python3-dev is needed for lru_dict
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-       python3 \
+       libpq-dev \
+       python3.9 \
        python3-pip \
        python3-setuptools \
        python3-wheel \
-       python3-dev gcc \
+       python3.9-dev gcc \
        make \
        postgresql-${POSTGRES_VERSION}-postgis-${POSTGIS_VERSION} \
        postgresql-${POSTGRES_VERSION}-postgis-${POSTGIS_VERSION}-scripts \
@@ -33,18 +34,18 @@ RUN apt-get update \
 # Install dependencies first (so layer is cached for fast rebuilds)
 # Need to create some stubs for setup.py to run.
 WORKDIR /host/
-COPY setup.py setup.cfg ./
+COPY setup.py ./
 RUN mkdir gisserver \
  && touch README.md \
  && echo '__version__ = "0.1.dev0"' > gisserver/__init__.py \
  && sed -i -e 's/ >= / == /' ./setup.py \
- && pip3 wheel --no-cache-dir --wheel-dir=/wheelhouse/ .[tests] \
+ && python3.9 -m pip wheel --no-cache-dir --wheel-dir=/wheelhouse/ .[tests] \
  && rm -vf /wheelhouse/django_gisserver* \
- && pip3 install --no-cache-dir /wheelhouse/*
+ && python3.9 -m pip install --no-cache-dir /wheelhouse/*
 
 # Install app
 COPY . /host/
-RUN pip3 install --find-links=/wheelhouse/ -e .[tests]
+RUN python3.9 -m pip install --find-links=/wheelhouse/ -e .[tests]
 ENV LANG=C.UTF-8 DATABASE_URL=postgresql://postgres@localhost/django-gisserver
 
 # Make sure Postgres starts on startup

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ test:          ## Run the tests
 
 docker-test:   ## Run the tests against Linux GIS library versions
 	docker build . -t django-gisserver
-	docker run -v $(ROOT_DIT):/host/ -e GISSERVER_USE_DB_RENDERING=1 --rm -it django-gisserver pytest -vvs
-	docker run -v $(ROOT_DIT):/host/ -e GISSERVER_USE_DB_RENDERING=0 --rm -it django-gisserver pytest -vvs
+	docker run -v $(ROOT_DIR):/host/ -e PYTHONPATH=. -e GISSERVER_USE_DB_RENDERING=1 --rm -it django-gisserver pytest -vvs
+	docker run -v $(ROOT_DIR):/host/ -e PYTHONPATH=. -e GISSERVER_USE_DB_RENDERING=0 --rm -it django-gisserver pytest -vvs
 
 retest:        ## Rerun the last failed tests.
 	PYTHONPATH=. pytest -vs --lf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ plugins = ["django_coverage_plugin"]
 # ==== black ====
 [tool.black]
 line-length = 99
-target-version = ['py39']
+target-version = ["py39"]
 
 # ==== ruff ====
 [tool.ruff]

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
@@ -75,5 +76,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
The dockerfile has been fixed to use python 3.9 to be able to run the tests, this had been broken for quite some time.