### PR TITLE
WFS post requests

### DIFF
--- a/gisserver/operations/base.py
+++ b/gisserver/operations/base.py
@@ -321,9 +321,6 @@ class WFSMethod:
         param_values = {param.name: param.value_from_query(KVP) for param in self.get_parameters()}
         param_values["NAMESPACES"] = self.namespaces
 
-        for param in self.get_parameters():
-            param_values[param.name] = param.value_from_query(KVP)
-
         # Update version if requested.
         # This is stored on the view, so exceptions also use it.
         if param_values.get("version"):

--- a/gisserver/parsers/fes20/filters.py
+++ b/gisserver/parsers/fes20/filters.py
@@ -35,6 +35,13 @@ class Filter:
         self.source = source
 
     @classmethod
+    def from_any(cls, text: AnyStr | NSElement):
+        if isinstance(text, NSElement):
+            return cls.from_xml(text)
+        else:
+            return cls.from_string(text)
+
+    @classmethod
     def from_string(cls, text: AnyStr) -> Filter:
         """Parse an XML <fes20:Filter> string.
 

--- a/gisserver/parsers/fes20/operators.py
+++ b/gisserver/parsers/fes20/operators.py
@@ -321,9 +321,9 @@ class NonIdOperator(Operator):
                     return ARRAY_LOOKUPS[lookup]
                 except KeyError:
                     raise OperationProcessingFailed(
-                        "filter",
                         f"Operator '{tag}' is not supported for "
                         f"the '{xsd_element.name}' property.",
+                        locator="filter",
                         status_code=400,  # not HTTP 500 here. Spec allows both.
                     ) from None
 

--- a/gisserver/parsers/xml.py
+++ b/gisserver/parsers/xml.py
@@ -156,3 +156,19 @@ def get_attribute(element: NSElement, name: str) -> str:
         raise ExternalParsingError(
             f"Element {element.tag} misses required attribute '{name}'"
         ) from None
+
+
+def split_ns(tag_or_value: str) -> tuple[str | None, str]:
+    """Split the element tag or attribute/text value into the namespace and
+    local name. The stdlib etree doesn't have the properties for this (lxml does).
+    """
+    # Tags may start with a `{ns}`
+    if tag_or_value.startswith("{"):
+        end = tag_or_value.index("}")
+        return tag_or_value[1:end], tag_or_value[end + 1 :]
+    # Attribute/text values may start with `ns:`
+    elif tag_or_value.find(":") >= 0:
+        end = tag_or_value.index(":")
+        return tag_or_value[1:end], tag_or_value[end + 1 :]
+    else:
+        return None, tag_or_value

--- a/gisserver/templates/gisserver/wfs/2.0.0/get_capabilities.xml
+++ b/gisserver/templates/gisserver/wfs/2.0.0/get_capabilities.xml
@@ -64,7 +64,7 @@
       <ows:DCP>
         <ows:HTTP>
           <ows:Get xlink:type="simple" xlink:href="{{ server_url }}"/>
-          {# <ows:Post xlink:type="simple" xlink:href="{{ server_url }}"/> #}
+          <ows:Post xlink:type="simple" xlink:href="{{ server_url }}"/>
         </ows:HTTP>
       </ows:DCP>
       {% for parameter in operation.get_parameters %}{% if parameter.in_capabilities and parameter.allowed_values %}

--- a/tests/gisserver/views/input.py
+++ b/tests/gisserver/views/input.py
@@ -1,7 +1,12 @@
 from gisserver.exceptions import OperationParsingFailed, OperationProcessingFailed
+from tests.requests import Url
 
-FILTERS = {
-    "simple": """
+# Tuples of the shape (name, url_type, filter)
+FILTERS = [
+    (
+        "simple",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -13,7 +18,11 @@ FILTERS = {
                 <fes:Literal>3.0</fes:Literal>
             </fes:PropertyIsGreaterThanOrEqualTo>
         </fes:Filter>""",
-    "value_datetimefield": """
+    ),
+    (
+        "value_datetimefield",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -25,7 +34,11 @@ FILTERS = {
                 <fes:ValueReference>created</fes:ValueReference>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "value_boolean": """
+    ),
+    (
+        "value_boolean",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -37,7 +50,11 @@ FILTERS = {
                 <fes:Literal>true</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "value_boolean_cast": """
+    ),
+    (
+        "value_boolean_cast",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -47,7 +64,11 @@ FILTERS = {
                 <fes:ValueReference>is_open</fes:ValueReference>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "value_array": """
+    ),
+    (
+        "value_array",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
             <fes:PropertyIsEqualTo>
@@ -55,7 +76,11 @@ FILTERS = {
                 <fes:Literal>black</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "value_array_lt": """
+    ),
+    (
+        "value_array_lt",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
             <fes:PropertyIsLessThan>
@@ -63,14 +88,22 @@ FILTERS = {
                 <fes:Literal>color</fes:Literal>
             </fes:PropertyIsLessThan>
         </fes:Filter>""",
-    "fes1": """
+    ),
+    (
+        "fes1",
+        Url.NORMAL,
+        """
         <Filter>
             <PropertyIsGreaterThanOrEqualTo>
                 <PropertyName>rating</PropertyName>
                 <Literal>3.0</Literal>
             </PropertyIsGreaterThanOrEqualTo>
         </Filter>""",
-    "like": """
+    ),
+    (
+        "like",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -82,7 +115,11 @@ FILTERS = {
                 <fes:Literal>C?fé*</fes:Literal>
             </fes:PropertyIsLike>
         </fes:Filter>""",
-    "bbox": """
+    ),
+    (
+        "bbox",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
             xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -100,7 +137,11 @@ FILTERS = {
                 </gml:Envelope>
             </fes:BBOX>
         </fes:Filter>""",
-    "bbox_default": """
+    ),
+    (
+        "bbox_default",
+        Url.NORMAL,
+        """
         <fes:Filter
             xmlns:ns16="http://example.org/gisserver"
             xmlns:wfs="http://www.opengis.net/wfs/2.0"
@@ -113,7 +154,11 @@ FILTERS = {
                 </gml:Envelope>
             </fes:BBOX>
         </fes:Filter>""",
-    "and": """
+    ),
+    (
+        "and",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
             xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -137,7 +182,11 @@ FILTERS = {
                 </fes:BBOX>
             </fes:And>
         </fes:Filter>""",
-    "gml:name": """
+    ),
+    (
+        "gml:name",
+        Url.NORMAL,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -149,10 +198,11 @@ FILTERS = {
                 <fes:Literal>Café Noir</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-}
-
-COMPLEX_FILTERS = {
-    "equal": """
+    ),
+    (
+        "equal",
+        Url.COMPLEX,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -164,7 +214,11 @@ COMPLEX_FILTERS = {
                 <fes:Literal>CloudCity</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "equal_xmlns": """
+    ),
+    (
+        "equal_xmlns",
+        Url.COMPLEX,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -176,7 +230,11 @@ COMPLEX_FILTERS = {
                 <fes:Literal>CloudCity</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "not_nil": """
+    ),
+    (
+        "not_nil",
+        Url.COMPLEX,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -189,7 +247,11 @@ COMPLEX_FILTERS = {
                 </fes:PropertyIsNil>
             </fes:Not>
         </fes:Filter>""",
-    "m2m": """
+    ),
+    (
+        "m2m",
+        Url.COMPLEX,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -201,11 +263,11 @@ COMPLEX_FILTERS = {
                 <fes:Literal>16:00:00</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-}
-
-
-FLATTENED_FILTERS = {
-    "equal": """
+    ),
+    (
+        "equal",
+        Url.FLAT,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -217,7 +279,11 @@ FLATTENED_FILTERS = {
                 <fes:Literal>CloudCity</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "equal_xmlns": """
+    ),
+    (
+        "equal_xmlns",
+        Url.FLAT,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -229,7 +295,11 @@ FLATTENED_FILTERS = {
                 <fes:Literal>CloudCity</fes:Literal>
             </fes:PropertyIsEqualTo>
         </fes:Filter>""",
-    "not_nil": """
+    ),
+    (
+        "not_nil",
+        Url.FLAT,
+        """
         <?xml version="1.0"?>
         <fes:Filter
              xmlns:fes="http://www.opengis.net/fes/2.0"
@@ -242,13 +312,19 @@ FLATTENED_FILTERS = {
                 </fes:PropertyIsNil>
             </fes:Not>
         </fes:Filter>""",
-}
+    ),
+]
 
+# Invalid Filters with their repective GET and POST request exceptions.
 INVALID_FILTERS = {
     "syntax": (
         """<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">FDFDS</fes:Filter""",
         OperationParsingFailed(
-            "Unable to parse FILTER argument: unclosed token: line 1, column 60",
+            "Unable to parse FILTER argument: unclosed token:",
+            locator="filter",
+        ),
+        OperationParsingFailed(
+            "Unable to parse XML: not well-formed (invalid token):",
             locator="filter",
         ),
     ),
@@ -264,7 +340,11 @@ INVALID_FILTERS = {
             </fes:PropertyIsGreaterThanOrEqualTo>
         </fes:Filter>""",
         OperationParsingFailed(
-            "Unable to parse FILTER argument: unbound prefix: line 2, column 8",
+            "Unable to parse FILTER argument: unbound prefix:",
+            locator="filter",
+        ),
+        OperationParsingFailed(
+            "Unable to parse XML: unbound prefix:",
             locator="filter",
         ),
     ),
@@ -281,7 +361,11 @@ INVALID_FILTERS = {
         </fes:PropertyIsGreaterThanOrEqualTofoo>
     </fes:Filter>""",
         OperationParsingFailed(
-            "Unable to parse FILTER argument: mismatched tag: line 9, column 10",
+            "Unable to parse FILTER argument: mismatched tag:",
+            locator="filter",
+        ),
+        OperationParsingFailed(
+            "Unable to parse XML: mismatched tag:",
             locator="filter",
         ),
     ),
@@ -301,6 +385,10 @@ INVALID_FILTERS = {
             "Invalid data for the 'rating' property: Can't cast 'TEXT' to double.",
             locator="filter",
         ),
+        OperationParsingFailed(
+            "Invalid data for the 'rating' property: Can't cast 'TEXT' to double.",
+            locator="filter",
+        ),
     ),
     "float_like": (
         """
@@ -314,6 +402,11 @@ INVALID_FILTERS = {
             <fes:Literal>2</fes:Literal>
         </fes:PropertyIsLike>
     </fes:Filter>""",
+        OperationProcessingFailed(
+            "Operator '{http://www.opengis.net/fes/2.0}PropertyIsLike'"
+            " is not supported for the 'rating' property.",
+            locator="filter",
+        ),
         OperationProcessingFailed(
             "Operator '{http://www.opengis.net/fes/2.0}PropertyIsLike'"
             " is not supported for the 'rating' property.",
@@ -339,6 +432,11 @@ INVALID_FILTERS = {
             " Date must be in YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ] format.",
             locator="filter",
         ),
+        OperationParsingFailed(
+            "Invalid data for the 'created' property:"
+            " Date must be in YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ] format.",
+            locator="filter",
+        ),
     ),
     "date_text": (
         """
@@ -352,6 +450,11 @@ INVALID_FILTERS = {
             <fes:Literal>abc</fes:Literal>
         </fes:PropertyIsGreaterThanOrEqualTo>
     </fes:Filter>""",
+        OperationParsingFailed(
+            "Invalid data for the 'created' property:"
+            " Date must be in YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ] format.",
+            locator="filter",
+        ),
         OperationParsingFailed(
             "Invalid data for the 'created' property:"
             " Date must be in YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ] format.",
@@ -383,17 +486,11 @@ INVALID_FILTERS = {
             " does not support comparing geometry properties: 'gml:boundedBy'.",
             locator="filter",
         ),
+        OperationParsingFailed(
+            "Unable to parse FILTER argument: not well-formed (invalid token):",
+            locator="filter",
+        ),
     ),
-}
-
-SORT_BY = {
-    "name": ("name", ["Café Noir", "Foo Bar"]),
-    "name-a": ("name A", ["Café Noir", "Foo Bar"]),
-    "name-asc": ("name ASC", ["Café Noir", "Foo Bar"]),
-    "name-d": ("name D", ["Foo Bar", "Café Noir"]),
-    "name-desc": ("name DESC", ["Foo Bar", "Café Noir"]),
-    "rating-desc": ("rating DESC", ["Café Noir", "Foo Bar"]),
-    "rating,name-asc": ("rating,name ASC", ["Foo Bar", "Café Noir"]),
 }
 
 GENERATED_FIELD_FILTER = {
@@ -426,3 +523,121 @@ GENERATED_FIELD_FILTER = {
         """
     ),
 }
+
+# Of the form (name, type, sort_by, expect)
+SORT_BY = [
+    ("name", Url.NORMAL, "name", ["Café Noir", "Foo Bar"]),
+    ("name-a", Url.NORMAL, "name A", ["Café Noir", "Foo Bar"]),
+    ("name-asc", Url.NORMAL, "name ASC", ["Café Noir", "Foo Bar"]),
+    ("name-d", Url.NORMAL, "name D", ["Foo Bar", "Café Noir"]),
+    ("name-desc", Url.NORMAL, "name DESC", ["Foo Bar", "Café Noir"]),
+    ("rating-desc", Url.NORMAL, "rating DESC", ["Café Noir", "Foo Bar"]),
+    ("rating,name-asc", Url.NORMAL, "rating,name ASC", ["Foo Bar", "Café Noir"]),
+    ("city/name", Url.COMPLEX, "city/name", ["Café Noir", "Foo Bar"]),
+    ("city/name-desc", Url.COMPLEX, "city/name DESC", ["Foo Bar", "Café Noir"]),
+    ("city-name", Url.FLAT, "city-name", ["Café Noir", "Foo Bar"]),
+    ("city-name-desc", Url.FLAT, "city-name DESC", ["Foo Bar", "Café Noir"]),
+]
+
+SORT_BY_XML = [
+    (
+        "name",
+        Url.NORMAL,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>name</fes:ValueReference>
+        </fes:SortProperty>
+        """,
+        ["Café Noir", "Foo Bar"],
+    ),
+    (
+        "name-asc",
+        Url.NORMAL,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>name</fes:ValueReference>
+            <fes:SortOrder>ASC</fes:SortOrder>
+        </fes:SortProperty>
+        """,
+        ["Café Noir", "Foo Bar"],
+    ),
+    (
+        "name-desc",
+        Url.NORMAL,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>name</fes:ValueReference>
+            <fes:SortOrder>DESC</fes:SortOrder>
+        </fes:SortProperty>
+        """,
+        ["Foo Bar", "Café Noir"],
+    ),
+    (
+        "rating-desc",
+        Url.NORMAL,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>rating</fes:ValueReference>
+            <fes:SortOrder>DESC</fes:SortOrder>
+        </fes:SortProperty>
+        """,
+        ["Café Noir", "Foo Bar"],
+    ),
+    (
+        "city-name",
+        Url.FLAT,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>city-name</fes:ValueReference>
+        </fes:SortProperty>
+        """,
+        ["Café Noir", "Foo Bar"],
+    ),
+    (
+        "city-name-desc",
+        Url.FLAT,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>city-name</fes:ValueReference>
+            <fes:SortOrder>DESC</fes:SortOrder>
+        </fes:SortProperty>
+        """,
+        ["Foo Bar", "Café Noir"],
+    ),
+    (
+        "city/name",
+        Url.COMPLEX,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>city/name</fes:ValueReference>
+        </fes:SortProperty>
+        """,
+        ["Café Noir", "Foo Bar"],
+    ),
+    (
+        "city/name-desc",
+        Url.COMPLEX,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>city/name</fes:ValueReference>
+            <fes:SortOrder>DESC</fes:SortOrder>
+        </fes:SortProperty>
+        """,
+        ["Foo Bar", "Café Noir"],
+    ),
+    (
+        "rating,name-asc",
+        Url.NORMAL,
+        """
+        <fes:SortProperty>
+            <fes:ValueReference>rating</fes:ValueReference>
+            <fes:SortOrder>ASC</fes:SortOrder>
+        </fes:SortProperty>
+        <fes:SortProperty>
+            <fes:ValueReference>name</fes:ValueReference>
+            <fes:SortOrder>ASC</fes:SortOrder>
+        </fes:SortProperty>
+        """,
+        ["Foo Bar", "Café Noir"],
+    ),
+]

--- a/tests/gisserver/views/test_describestoredqueries.py
+++ b/tests/gisserver/views/test_describestoredqueries.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.utils import WFS_20_XSD, assert_xml_equal, validate_xsd
+from tests.requests import Get, Post, parametrize_response
+from tests.utils import WFS_20_XSD, XML_NS, assert_xml_equal, validate_xsd
 
 # enable for all tests in this file
 pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
@@ -9,9 +10,16 @@ pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
 class TestDescribeStoredQueries:
     """All tests for the DescribeStoredQueries method."""
 
-    def test_get(self, client):
+    @parametrize_response(
+        Get("?SERVICE=WFS&REQUEST=DescribeStoredQueries&VERSION=2.0.0"),
+        Post(
+            f"""<DescribeStoredQueries version="2.0.0" service="WFS" {XML_NS}>
+                </DescribeStoredQueries>
+                """
+        ),
+    )
+    def test_get(self, response):
         """Prove that the happy flow works"""
-        response = client.get("/v1/wfs/?SERVICE=WFS&REQUEST=DescribeStoredQueries&VERSION=2.0.0")
         content = response.content.decode()
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content

--- a/tests/gisserver/views/test_getfeature_resourceid.py
+++ b/tests/gisserver/views/test_getfeature_resourceid.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.utils import NAMESPACES, WFS_20_XSD, read_response, validate_xsd
+from tests.requests import Get, Post, parametrize_response
+from tests.utils import NAMESPACES, WFS_20_XSD, XML_NS, read_response, validate_xsd
 
 # enable for all tests in this file
 pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
@@ -12,15 +13,23 @@ class TestGetFeature:
     The methods need to have at least one datatype, otherwise not all content is rendered.
     """
 
-    def test_resource_id(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get(
+            lambda id: "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
+            f"&RESOURCEID=restaurant.{id}"
+        ),
+        Post(
+            lambda id: f"""<GetFeature service="WFS" version="2.0.0"
+				resourceId="restaurant.{id}" {XML_NS}>
+				</GetFeature>"""
+        ),
+    )
+    def test_resource_id(self, restaurant, bad_restaurant, response):
         """Prove that fetching objects by ID works."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
-            f"&RESOURCEID=restaurant.{restaurant.id}"
-        )
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 200, content
+        res = response(restaurant.id)
+        content = read_response(res)
+        assert res["content-type"] == "text/xml; charset=utf-8", content
+        assert res.status_code == 200, content
         assert "</wfs:FeatureCollection>" in content
 
         # Validate against the WFS 2.0 XSD
@@ -33,12 +42,16 @@ class TestGetFeature:
         names = [res.find("app:name", namespaces=NAMESPACES).text for res in restaurants]
         assert names == ["Café Noir"]
 
-    def test_resource_id_unknown_id(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get("?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&RESOURCEID=restaurant.0"),
+        Post(
+            f"""<GetFeature service="WFS" version="2.0.0"
+				resourceId="restaurant.0" {XML_NS}>
+				</GetFeature>"""
+        ),
+    )
+    def test_resource_id_unknown_id(self, restaurant, bad_restaurant, response):
         """Prove that unknown IDs simply return an empty list."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=restaurant"
-            "&RESOURCEID=restaurant.0"
-        )
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -53,16 +66,24 @@ class TestGetFeature:
         members = xml_doc.findall("wfs:member", namespaces=NAMESPACES)
         assert len(members) == 0
 
-    def test_resource_id_typename_mismatch(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get(
+            lambda id: "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=mini-restaurant"
+            f"&RESOURCEID=restaurant.{id}"
+        ),
+        Post(
+            lambda id: f"""<GetFeature service="WFS" version="2.0.0"
+				resourceId="restaurant.{id}" {XML_NS}>
+                <Query typeNames="mini-restaurant"></Query>
+				</GetFeature>"""
+        ),
+    )
+    def test_resource_id_typename_mismatch(self, restaurant, bad_restaurant, response):
         """Prove that TYPENAMES should be omitted, or match the RESOURCEID."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
-            "&TYPENAMES=mini-restaurant"
-            f"&RESOURCEID=restaurant.{restaurant.id}"
-        )
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 400, content
+        res = response(restaurant.id)
+        content = read_response(res)
+        assert res["content-type"] == "text/xml; charset=utf-8", content
+        assert res.status_code == 400, content
         assert "</ows:Exception>" in content
 
         xml_doc = validate_xsd(content, WFS_20_XSD)
@@ -76,11 +97,16 @@ class TestGetFeature:
             "the RESOURCEID type should be included in TYPENAMES."
         )
 
-    def test_resource_id_invalid(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get("?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&RESOURCEID=restaurant.ABC"),
+        Post(
+            f"""<GetFeature service="WFS" version="2.0.0"
+				resourceId="restaurant.ABC" {XML_NS}>
+				</GetFeature>"""
+        ),
+    )
+    def test_resource_id_invalid(self, restaurant, bad_restaurant, response):
         """Prove that TYPENAMES should be omitted, or match the RESOURCEID."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&RESOURCEID=restaurant.ABC"
-        )
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 400, content
@@ -94,15 +120,23 @@ class TestGetFeature:
         assert exception.attrib["locator"] == "resourceId", message
         # message differs in Django versions
 
-    def test_resource_id_multiple(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get(
+            lambda id1, id2: "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
+            f"&RESOURCEID=restaurant.{id1},restaurant.{id2}"
+        ),
+        Post(
+            lambda id1, id2: f"""<GetFeature service="WFS" version="2.0.0"
+				resourceId="restaurant.{id1},restaurant.{id2}" {XML_NS}>
+				</GetFeature>"""
+        ),
+    )
+    def test_resource_id_multiple(self, client, restaurant, bad_restaurant, response):
         """Prove that fetching multiple IDs works."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
-            f"&RESOURCEID=restaurant.{restaurant.id},restaurant.{bad_restaurant.id}"
-        )
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 200, content
+        res = response(restaurant.id, bad_restaurant.id)
+        content = read_response(res)
+        assert res["content-type"] == "text/xml; charset=utf-8", content
+        assert res.status_code == 200, content
         assert "</wfs:FeatureCollection>" in content
 
         # Validate against the WFS 2.0 XSD

--- a/tests/gisserver/views/test_getfeature_sort.py
+++ b/tests/gisserver/views/test_getfeature_sort.py
@@ -1,71 +1,67 @@
 import pytest
 
-from tests.gisserver.views.input import SORT_BY
-from tests.utils import NAMESPACES, WFS_20_XSD, read_response, validate_xsd
+from tests.gisserver.views.input import SORT_BY, SORT_BY_XML
+from tests.requests import Get, Post, parametrize_response
+from tests.utils import NAMESPACES, WFS_20_XSD, XML_NS, read_response, validate_xsd
 
 # enable for all tests in this file
 pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
 
 
 @pytest.mark.django_db
-class TestGetFeature:
+class TestGetFeatureSort:
     """All tests for the GetFeature method.
     The methods need to have at least one datatype, otherwise not all content is rendered.
     """
 
-    @pytest.mark.parametrize("ordering", list(SORT_BY.keys()))
-    def test_get_sort_by(self, client, restaurant, bad_restaurant, ordering):
+    @parametrize_response(
+        *(
+            [
+                Get(
+                    "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=restaurant"
+                    f"&SORTBY={sort_by}",
+                    id=name,
+                    expect=expect,
+                    url=url,
+                )
+                for (name, url, sort_by, expect) in SORT_BY
+            ]
+            + [
+                Post(
+                    f"""<GetFeature version="2.0.0" service="WFS" {XML_NS}>
+                <Query typeNames="restaurant">
+                    <fes:SortBy>
+                        {sort_by}
+                    </fes:SortBy>
+                </Query>
+                </GetFeature>
+                """,
+                    id=name,
+                    expect=expect,
+                    url=url,
+                )
+                for (name, url, sort_by, expect) in SORT_BY_XML
+            ]
+        )
+    )
+    def test_get_sort_by(self, restaurant, bad_restaurant, response):
         """Prove that that sorting with SORTBY=... works"""
-        sort_by, expect = SORT_BY[ordering]
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=restaurant"
-            f"&SORTBY={sort_by}"
-        )
-        self._assert_sort(response, expect)
+        _assert_sort(response, response.expect)
 
-    def _assert_sort(self, response, expect):
-        """Common logic for sort tests"""
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 200, content
-        assert "</wfs:FeatureCollection>" in content
 
-        # Validate against the WFS 2.0 XSD
-        xml_doc = validate_xsd(content, WFS_20_XSD)
-        assert xml_doc.attrib["numberMatched"] == "2"
-        assert xml_doc.attrib["numberReturned"] == "2"
+def _assert_sort(response, expect):
+    """Common logic for sort tests"""
+    content = read_response(response)
+    assert response["content-type"] == "text/xml; charset=utf-8", content
+    assert response.status_code == 200, content
+    assert "</wfs:FeatureCollection>" in content
 
-        # Test sort ordering.
-        restaurants = xml_doc.findall("wfs:member/app:restaurant", namespaces=NAMESPACES)
-        names = [res.find("app:name", namespaces=NAMESPACES).text for res in restaurants]
-        assert names == expect
+    # Validate against the WFS 2.0 XSD
+    xml_doc = validate_xsd(content, WFS_20_XSD)
+    assert xml_doc.attrib["numberMatched"] == "2"
+    assert xml_doc.attrib["numberReturned"] == "2"
 
-    SORT_BY_COMPLEX = {
-        "city/name": ("city/name", ["Café Noir", "Foo Bar"]),
-        "city/name-desc": ("city/name DESC", ["Foo Bar", "Café Noir"]),
-    }
-
-    @pytest.mark.parametrize("ordering", list(SORT_BY_COMPLEX.keys()))
-    def test_get_sort_by_complex(self, client, restaurant, bad_restaurant, ordering):
-        """Prove that sorting on XPath works for complex types"""
-        sort_by, expect = self.SORT_BY_COMPLEX[ordering]
-        response = client.get(
-            "/v1/wfs-complextypes/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
-            f"&TYPENAMES=restaurant&SORTBY={sort_by}"
-        )
-        self._assert_sort(response, expect)
-
-    SORT_BY_FLATTENED = {
-        "city-name": ("city-name", ["Café Noir", "Foo Bar"]),
-        "city-name-desc": ("city-name DESC", ["Foo Bar", "Café Noir"]),
-    }
-
-    @pytest.mark.parametrize("ordering", list(SORT_BY_FLATTENED.keys()))
-    def test_get_sort_by_flattened(self, client, restaurant, bad_restaurant, ordering):
-        """Prove that sorting on XPath works for flattened types"""
-        sort_by, expect = self.SORT_BY_FLATTENED[ordering]
-        response = client.get(
-            "/v1/wfs-flattened/?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0"
-            f"&TYPENAMES=restaurant&SORTBY={sort_by}"
-        )
-        self._assert_sort(response, expect)
+    # Test sort ordering.
+    restaurants = xml_doc.findall("wfs:member/app:restaurant", namespaces=NAMESPACES)
+    names = [res.find("app:name", namespaces=NAMESPACES).text for res in restaurants]
+    assert names == expect

--- a/tests/gisserver/views/test_getpropertyvalue.py
+++ b/tests/gisserver/views/test_getpropertyvalue.py
@@ -4,33 +4,56 @@ import django
 import pytest
 
 from tests.gisserver.views.input import (
-    COMPLEX_FILTERS,
     FILTERS,
-    FLATTENED_FILTERS,
     INVALID_FILTERS,
     SORT_BY,
+    SORT_BY_XML,
 )
-from tests.test_gisserver.models import Restaurant
-from tests.utils import NAMESPACES, WFS_20_XSD, assert_xml_equal, read_response, validate_xsd
+from tests.requests import Get, Post, parametrize_response
+from tests.utils import (
+    NAMESPACES,
+    WFS_20_XSD,
+    XML_NS,
+    assert_xml_equal,
+    clean_filter_for_xml,
+    read_response,
+    validate_xsd,
+)
 
 # enable for all tests in this file
 pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
+gml32 = quote_plus("application/gml+xml; version=3.2")
 
 
 @pytest.mark.django_db
 class TestGetPropertyValue:
     """All tests for the GetPropertyValue method."""
 
-    @pytest.mark.parametrize(
-        "xpath", ["name", "app:name", "app:restaurant/app:name", "/restaurant/name"]
-    )
-    def test_get(self, client, restaurant, bad_restaurant, xpath):
-        """Prove that the happy flow works"""
-        gml32 = quote_plus("application/gml+xml; version=3.2")
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
-            f"&VALUEREFERENCE={xpath}&OUTPUTFORMAT={gml32}"
+    XPATHS = ["name", "app:name", "app:restaurant/app:name", "/restaurant/name"]
+
+    @parametrize_response(
+        *(
+            [
+                Get(
+                    f"?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+                    f"&VALUEREFERENCE={xpath}&OUTPUTFORMAT={gml32}"
+                )
+                for xpath in XPATHS
+            ]
+            + [
+                Post(
+                    f"""<GetPropertyValue version="2.0.0" service="WFS" outputFormat="application/gml+xml; version=3.2" valueReference="{xpath}" {XML_NS}>
+                <Query typeNames="restaurant">
+                </Query>
+                </GetPropertyValue>
+                """
+                )
+                for xpath in XPATHS
+            ]
         )
+    )
+    def test_get(self, restaurant, bad_restaurant, response):
+        """Prove that the happy flow works"""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -45,27 +68,36 @@ class TestGetPropertyValue:
         assert_xml_equal(
             content,
             f"""<wfs:ValueCollection
-       xmlns:app="http://example.org/gisserver"
-       xmlns:gml="http://www.opengis.net/gml/3.2"
-       xmlns:wfs="http://www.opengis.net/wfs/2.0"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
-       timeStamp="{timestamp}" numberMatched="2" numberReturned="2">
-  <wfs:member>
-    <app:name>Café Noir</app:name>
-  </wfs:member>
-  <wfs:member>
-    <app:name>Foo Bar</app:name>
-  </wfs:member>
-</wfs:ValueCollection>""",  # noqa: E501
+                    xmlns:app="http://example.org/gisserver"
+                    xmlns:gml="http://www.opengis.net/gml/3.2"
+                    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+                    timeStamp="{timestamp}" numberMatched="2" numberReturned="2">
+                <wfs:member>
+                    <app:name>Café Noir</app:name>
+                </wfs:member>
+                <wfs:member>
+                    <app:name>Foo Bar</app:name>
+                </wfs:member>
+                </wfs:ValueCollection>""",  # noqa: E501
         )
 
-    def test_get_location(self, client, restaurant, coordinates):
-        """Prove that rendering geometry values also works"""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
             "&VALUEREFERENCE=location"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue version="2.0.0" service="WFS" valueReference="location" {XML_NS}>
+                <Query typeNames="restaurant">
+                </Query>
+                </GetPropertyValue>
+                """
+        ),
+    )
+    def test_get_location(self, restaurant, coordinates, response):
+        """Prove that rendering geometry values also works"""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -80,29 +112,37 @@ class TestGetPropertyValue:
         assert_xml_equal(
             content,
             f"""<wfs:ValueCollection
-       xmlns:app="http://example.org/gisserver"
-       xmlns:gml="http://www.opengis.net/gml/3.2"
-       xmlns:wfs="http://www.opengis.net/wfs/2.0"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
-       timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
-  <wfs:member>
-    <app:location>
-      <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::4326">
-        <gml:pos srsDimension="2">{coordinates.point1_xml_wgs84}</gml:pos>
-      </gml:Point>
-    </app:location>
-  </wfs:member>
-</wfs:ValueCollection>""",  # noqa: E501
+                xmlns:app="http://example.org/gisserver"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+                timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
+            <wfs:member>
+                <app:location>
+                <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::4326">
+                    <gml:pos srsDimension="2">{coordinates.point1_xml_wgs84}</gml:pos>
+                </gml:Point>
+                </app:location>
+            </wfs:member>
+            </wfs:ValueCollection>""",  # noqa: E501
         )
 
-    def test_get_location_null(self, client):
-        """Prove that the empty geometry values don't crash the rendering."""
-        Restaurant.objects.create(name="Empty")
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
             "&VALUEREFERENCE=location"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue version="2.0.0" service="WFS" valueReference="location" {XML_NS}>
+                <Query typeNames="restaurant">
+                </Query>
+                </GetPropertyValue>
+                """
+        ),
+    )
+    def test_get_location_null(self, empty_restaurant, response):
+        """Prove that the empty geometry values don't crash the rendering."""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -118,24 +158,33 @@ class TestGetPropertyValue:
         assert_xml_equal(
             content,
             f"""<wfs:ValueCollection
-               xmlns:app="http://example.org/gisserver"
-               xmlns:gml="http://www.opengis.net/gml/3.2"
-               xmlns:wfs="http://www.opengis.net/wfs/2.0"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
-               timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
-          <wfs:member>
-            <app:location xsi:nil="true"/>
-          </wfs:member>
-        </wfs:ValueCollection>""",  # noqa: E501
+                xmlns:app="http://example.org/gisserver"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+                timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
+            <wfs:member>
+                <app:location xsi:nil="true"/>
+            </wfs:member>
+            </wfs:ValueCollection>""",  # noqa: E501
         )
 
-    def test_get_tags_array(self, client, restaurant):
-        """Prove that the rendering an array field produces some WFS-compatible response."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
             "&VALUEREFERENCE=tags"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue version="2.0.0" service="WFS" valueReference="tags" {XML_NS}>
+                <Query typeNames="restaurant">
+                </Query>
+                </GetPropertyValue>
+                """
+        ),
+    )
+    def test_get_tags_array(self, restaurant, response):
+        """Prove that the rendering an array field produces some WFS-compatible response."""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -150,23 +199,32 @@ class TestGetPropertyValue:
         assert_xml_equal(
             content,
             f"""<wfs:ValueCollection
-               xmlns:app="http://example.org/gisserver"
-               xmlns:gml="http://www.opengis.net/gml/3.2"
-               xmlns:wfs="http://www.opengis.net/wfs/2.0"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
-               timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
-          <wfs:member><app:tags>cafe</app:tags></wfs:member>
-          <wfs:member><app:tags>black</app:tags></wfs:member>
-        </wfs:ValueCollection>""",  # noqa: E501
+                xmlns:app="http://example.org/gisserver"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+                timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
+            <wfs:member><app:tags>cafe</app:tags></wfs:member>
+            <wfs:member><app:tags>black</app:tags></wfs:member>
+            </wfs:ValueCollection>""",  # noqa: E501
         )
 
-    def test_get_attribute(self, client, restaurant, bad_restaurant):
-        """Prove that referencing attributes works"""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
             "&VALUEREFERENCE=@gml:id"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue version="2.0.0" service="WFS" valueReference="@gml:id" {XML_NS}>
+                <Query typeNames="restaurant">
+                </Query>
+                </GetPropertyValue>
+                """
+        ),
+    )
+    def test_get_attribute(self, restaurant, bad_restaurant, response):
+        """Prove that referencing attributes works"""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -181,71 +239,75 @@ class TestGetPropertyValue:
         assert_xml_equal(
             content,
             f"""<wfs:ValueCollection
-       xmlns:app="http://example.org/gisserver"
-       xmlns:gml="http://www.opengis.net/gml/3.2"
-       xmlns:wfs="http://www.opengis.net/wfs/2.0"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
-       timeStamp="{timestamp}" numberMatched="2" numberReturned="2">
-  <wfs:member>restaurant.{restaurant.pk}</wfs:member>
-  <wfs:member>restaurant.{bad_restaurant.pk}</wfs:member>
-</wfs:ValueCollection>""",  # noqa: E501
+                xmlns:app="http://example.org/gisserver"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+                timeStamp="{timestamp}" numberMatched="2" numberReturned="2">
+            <wfs:member>restaurant.{restaurant.pk}</wfs:member>
+            <wfs:member>restaurant.{bad_restaurant.pk}</wfs:member>
+            </wfs:ValueCollection>""",  # noqa: E501
         )
 
-    @pytest.mark.parametrize("filter_name", list(FILTERS.keys()))
-    def test_get_filter(self, client, restaurant, bad_restaurant, filter_name):
+    @parametrize_response(
+        *(
+            [
+                Get(
+                    "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+                    "&VALUEREFERENCE=name&FILTER=" + quote_plus(filter.strip()),
+                    id=name,
+                    url=url,
+                )
+                for (name, url, filter) in FILTERS
+            ]
+            + [
+                Post(
+                    f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name" {XML_NS}>
+            <Query typeNames="restaurant">
+            {clean_filter_for_xml(filter).strip()}
+            </Query>
+            </GetPropertyValue>
+            """,
+                    id=name,
+                    url=url,
+                )
+                for (name, url, filter) in FILTERS
+            ]
+        )
+    )
+    def test_get_filter(self, client, restaurant, restaurant_m2m, bad_restaurant, response):
         """Prove that that parsing FILTER=<fes:Filter>... works"""
-        filter = FILTERS[filter_name].strip()
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
-            "&VALUEREFERENCE=name&FILTER=" + quote_plus(filter)
+        _assert_filter(response)
+
+    @parametrize_response(
+        *(
+            [
+                Get(
+                    "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+                    "&VALUEREFERENCE=name&FILTER=" + quote_plus(filter.strip()),
+                    expect=expect,
+                    id=name,
+                )
+                for name, (filter, expect, _) in INVALID_FILTERS.items()
+            ]
+            + [
+                Post(
+                    f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name" {XML_NS}>
+                <Query typeNames="restaurant">
+                {clean_filter_for_xml(filter).strip()}
+                </Query>
+                </GetPropertyValue>
+                """,
+                    expect=expect,
+                    id=name,
+                )
+                for name, (filter, _, expect) in INVALID_FILTERS.items()
+            ]
         )
-        self._assert_filter(response)
-
-    def _assert_filter(self, response, expect="Café Noir"):
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 200, content
-        assert "</wfs:ValueCollection>" in content
-
-        # Validate against the WFS 2.0 XSD
-        xml_doc = validate_xsd(content, WFS_20_XSD)
-        assert xml_doc.attrib["numberMatched"] == "1"
-        assert xml_doc.attrib["numberReturned"] == "1"
-
-        # Assert that the correct object was matched
-        name = xml_doc.find("wfs:member/app:name", namespaces=NAMESPACES).text
-        assert name == expect
-
-    @pytest.mark.parametrize("filter_name", list(COMPLEX_FILTERS.keys()))
-    def test_get_filter_complex(self, client, restaurant_m2m, bad_restaurant, filter_name):
-        """Prove that that parsing FILTER=<fes:Filter>... works for complex types"""
-        filter = COMPLEX_FILTERS[filter_name].strip()
-        response = client.get(
-            "/v1/wfs-complextypes/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
-            "&TYPENAMES=restaurant&VALUEREFERENCE=name&FILTER=" + quote_plus(filter)
-        )
-        self._assert_filter(response)
-
-    @pytest.mark.parametrize("filter_name", list(FLATTENED_FILTERS.keys()))
-    def test_get_filter_flattened(self, client, restaurant, bad_restaurant, filter_name):
-        """Prove that that parsing FILTER=<fes:Filter>... works for flattened types"""
-        filter = FLATTENED_FILTERS[filter_name].strip()
-        response = client.get(
-            "/v1/wfs-flattened/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
-            "&TYPENAMES=restaurant&VALUEREFERENCE=name&FILTER=" + quote_plus(filter)
-        )
-        self._assert_filter(response)
-
-    @pytest.mark.parametrize("filter_name", list(INVALID_FILTERS.keys()))
-    def test_get_filter_invalid(self, client, restaurant, filter_name):
+    )
+    def test_get_filter_invalid(self, restaurant, response):
         """Prove that that parsing FILTER=<fes:Filter>... works"""
-        filter, expect_exception = INVALID_FILTERS[filter_name]
-
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
-            "&VALUEREFERENCE=name&FILTER=" + quote_plus(filter.strip())
-        )
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 400, content
@@ -256,17 +318,26 @@ class TestGetPropertyValue:
         exception = xml_doc.find("ows:Exception", NAMESPACES)
         message = exception.find("ows:ExceptionText", NAMESPACES).text
 
-        assert exception.attrib["exceptionCode"] == expect_exception.code, message
-        assert message == expect_exception.text
+        assert exception.attrib["exceptionCode"] == response.expect.code, message
+        assert message.startswith(response.expect.text)
 
-    def test_get_unauth(self, client):
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=denied-feature"
+            "&VALUEREFERENCE=name"
+        ),
+        Post(
+            f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name" {XML_NS}>
+            <Query typeNames="denied-feature">
+            </Query>
+            </GetPropertyValue>
+            """
+        ),
+    )
+    def test_get_unauth(self, response):
         """Prove that features may block access.
         Note that HTTP 403 is not in the WFS 2.0 spec, but still useful to have.
         """
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=denied-feature"
-            "&VALUEREFERENCE=name"
-        )
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 403, content
@@ -280,18 +351,33 @@ class TestGetPropertyValue:
         message = exception.find("ows:ExceptionText", NAMESPACES).text
         assert message == "No access to this feature."
 
-    def test_pagination(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get(
+            lambda start_index: "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+            f"&VALUEREFERENCE=name&SORTBY=name&COUNT=1&STARTINDEX={start_index}",
+        ),
+        Post(
+            lambda start_index: f"""<GetPropertyValue version="2.0.0" service="WFS" count="1" startIndex="{start_index}" valueReference="name" {XML_NS}>
+                <Query typeNames="restaurant">
+                    <fes:SortBy>
+                        <fes:SortProperty>
+                            <fes:ValueReference>name</fes:ValueReference>
+                            <fes:SortOrder>ASC</fes:SortOrder>
+                        </fes:SortProperty>
+                    </fes:SortBy>
+                </Query>
+                </GetPropertyValue>
+                """,
+        ),
+    )
+    def test_pagination(self, client, restaurant, bad_restaurant, response):
         """Prove that that parsing BBOX=... works"""
         names = []
-        url = (
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
-            "&VALUEREFERENCE=name&SORTBY=name"
-        )
-        for _ in range(4):  # test whether last page stops
-            response = client.get(f"{url}&COUNT=1")
-            content = read_response(response)
-            assert response["content-type"] == "text/xml; charset=utf-8", content
-            assert response.status_code == 200, content
+        for start_index in range(4):  # test whether last page stops
+            res = response(start_index)
+            content = read_response(res)
+            assert res["content-type"] == "text/xml; charset=utf-8", content
+            assert res.status_code == 200, content
             assert "</wfs:ValueCollection>" in content
 
             # Validate against the WFS 2.0 XSD
@@ -310,14 +396,38 @@ class TestGetPropertyValue:
         assert len(names) == 2
         assert names[0] != names[1]
 
-    @pytest.mark.parametrize("ordering", list(SORT_BY.keys()))
-    def test_get_sort_by(self, client, restaurant, bad_restaurant, ordering):
-        """Prove that that parsing BBOX=... works"""
-        sort_by, expect = SORT_BY[ordering]
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
-            f"&VALUEREFERENCE=name&SORTBY={sort_by}"
+    @parametrize_response(
+        *(
+            [
+                Get(
+                    "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+                    f"&VALUEREFERENCE=name&SORTBY={sort_by}",
+                    id=name,
+                    expect=expect,
+                    url=url,
+                )
+                for (name, url, sort_by, expect) in SORT_BY
+            ]
+            + [
+                Post(
+                    f"""<GetPropertyValue version="2.0.0" service="WFS" valueReference="name" {XML_NS}>
+                <Query typeNames="restaurant">
+                    <fes:SortBy>
+                        {sort_by}
+                    </fes:SortBy>
+                </Query>
+                </GetPropertyValue>
+                """,
+                    id=name,
+                    expect=expect,
+                    url=url,
+                )
+                for (name, url, sort_by, expect) in SORT_BY_XML
+            ]
         )
+    )
+    def test_get_sort_by(self, client, restaurant, bad_restaurant, response):
+        """Prove that that parsing BBOX=... works"""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -331,17 +441,26 @@ class TestGetPropertyValue:
         # Test sort ordering.
         members = xml_doc.findall("wfs:member", namespaces=NAMESPACES)
         names = [res.find("app:name", namespaces=NAMESPACES).text for res in members]
-        assert names == expect
+        assert names == response.expect
 
-    def test_resource_id(self, client, restaurant, bad_restaurant):
+    @parametrize_response(
+        Get(
+            lambda id: "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
+            f"&RESOURCEID=restaurant.{id}&VALUEREFERENCE=name",
+        ),
+        Post(
+            lambda id: f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name"
+                resourceId="restaurant.{id}" {XML_NS}>
+                </GetPropertyValue>
+                """,
+        ),
+    )
+    def test_resource_id(self, restaurant, bad_restaurant, response):
         """Prove that fetching objects by ID works."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
-            f"&RESOURCEID=restaurant.{restaurant.id}&VALUEREFERENCE=name"
-        )
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 200, content
+        res = response(restaurant.id)
+        content = read_response(res)
+        assert res["content-type"] == "text/xml; charset=utf-8", content
+        assert res.status_code == 200, content
         assert "</wfs:ValueCollection>" in content
 
         # Validate against the WFS 2.0 XSD
@@ -354,12 +473,20 @@ class TestGetPropertyValue:
         names = [res.find("app:name", namespaces=NAMESPACES).text for res in members]
         assert names == ["Café Noir"]
 
-    def test_resource_id_unknown_id(self, client, restaurant, bad_restaurant):
-        """Prove that unknown IDs simply return an empty list."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0&TYPENAMES=restaurant"
             "&RESOURCEID=restaurant.0&VALUEREFERENCE=name"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name" resourceId="restaurant.0" {XML_NS}>
+                <Query typeNames="restaurant"></Query>
+                </GetPropertyValue>
+                """
+        ),
+    )
+    def test_resource_id_unknown_id(self, restaurant, bad_restaurant, response):
+        """Prove that unknown IDs simply return an empty list."""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -374,16 +501,25 @@ class TestGetPropertyValue:
         members = xml_doc.findall("wfs:member", namespaces=NAMESPACES)
         assert len(members) == 0
 
-    def test_resource_id_typename_mismatch(self, client, restaurant, bad_restaurant):
-        """Prove that TYPENAMES should be omitted, or match the RESOURCEID."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
+    @parametrize_response(
+        Get(
+            lambda id: "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
             "&TYPENAMES=mini-restaurant"
-            f"&RESOURCEID=restaurant.{restaurant.id}&VALUEREFERENCE=location"
-        )
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 400, content
+            f"&RESOURCEID=restaurant.{id}&VALUEREFERENCE=location",
+        ),
+        Post(
+            lambda id: f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="location" resourceId="restaurant.{id}" {XML_NS}>
+                <Query typeNames="mini-restaurant"></Query>
+                </GetPropertyValue>
+                """,
+        ),
+    )
+    def test_resource_id_typename_mismatch(self, restaurant, bad_restaurant, response):
+        """Prove that TYPENAMES should be omitted, or match the RESOURCEID."""
+        res = response(restaurant.id)
+        content = read_response(res)
+        assert res["content-type"] == "text/xml; charset=utf-8", content
+        assert res.status_code == 400, content
         assert "</ows:Exception>" in content
 
         xml_doc = validate_xsd(content, WFS_20_XSD)
@@ -397,12 +533,19 @@ class TestGetPropertyValue:
             "the RESOURCEID type should be included in TYPENAMES."
         )
 
-    def test_resource_id_invalid(self, client, restaurant, bad_restaurant):
-        """Prove that TYPENAMES should be omitted, or match the RESOURCEID."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
             "&RESOURCEID=restaurant.ABC&VALUEREFERENCE=name"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name" resourceId="restaurant.ABC" {XML_NS}>
+                </GetPropertyValue>
+                """
+        ),
+    )
+    def test_resource_id_invalid(self, restaurant, bad_restaurant, response):
+        """Prove that TYPENAMES should be omitted, or match the RESOURCEID."""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 400, content
@@ -416,16 +559,25 @@ class TestGetPropertyValue:
         assert exception.attrib["locator"] == "resourceId", message
         # message differs in Django versions
 
-    def test_get_feature_by_id_stored_query(self, client, restaurant, bad_restaurant):
-        """Prove that fetching objects by ID works."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
+    @parametrize_response(
+        Get(
+            lambda id: "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
             f"&STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::GetFeatureById"
-            f"&ID=restaurant.{restaurant.id}&VALUEREFERENCE=name"
-        )
-        content = read_response(response)
-        assert response["content-type"] == "text/xml; charset=utf-8", content
-        assert response.status_code == 200, content
+            f"&ID=restaurant.{id}&VALUEREFERENCE=name"
+        ),
+        Post(
+            lambda id: f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name"
+                storedQueryId="urn:ogc:def:query:OGC-WFS::GetFeatureById" id="restaurant.{id}" {XML_NS}>
+                </GetPropertyValue>
+            """,
+        ),
+    )
+    def test_get_feature_by_id_stored_query(self, restaurant, bad_restaurant, response):
+        """Prove that fetching objects by ID works."""
+        res = response(restaurant.id)
+        content = read_response(res)
+        assert res["content-type"] == "text/xml; charset=utf-8", content
+        assert res.status_code == 200, content
         assert "</app:restaurant>" not in content
         assert "</wfs:FeatureCollection>" not in content
 
@@ -434,16 +586,23 @@ class TestGetPropertyValue:
         assert_xml_equal(
             content,
             """<app:name xmlns:app="http://example.org/gisserver"
-                         xmlns:gml="http://www.opengis.net/gml/3.2">Café Noir</app:name>""",
+                xmlns:gml="http://www.opengis.net/gml/3.2">Café Noir</app:name>""",
         )
 
-    def test_get_feature_by_id_bad_id(self, client, restaurant, bad_restaurant):
-        """Prove that invalid IDs are properly handled."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
             "&STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::GetFeatureById"
             "&ID=restaurant.ABC&VALUEREFERENCE=name"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name"
+                storedQueryId="urn:ogc:def:query:OGC-WFS::GetFeatureById" id="restaurant.ABC" {XML_NS}>
+                </GetPropertyValue>"""
+        ),
+    )
+    def test_get_feature_by_id_bad_id(self, restaurant, bad_restaurant, response):
+        """Prove that invalid IDs are properly handled."""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 400, content
@@ -461,13 +620,21 @@ class TestGetPropertyValue:
         )
         assert message == expect
 
-    def test_get_feature_by_id_404(self, client, restaurant, bad_restaurant):
-        """Prove that missing IDs are properly handled."""
-        response = client.get(
-            "/v1/wfs/?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
+    @parametrize_response(
+        Get(
+            "?SERVICE=WFS&REQUEST=GetPropertyValue&VERSION=2.0.0"
             "&STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::GetFeatureById"
             "&ID=restaurant.0&VALUEREFERENCE=name"
-        )
+        ),
+        Post(
+            f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name"
+                storedQueryId="urn:ogc:def:query:OGC-WFS::GetFeatureById" id="restaurant.0" {XML_NS}>
+                </GetPropertyValue>
+            """
+        ),
+    )
+    def test_get_feature_by_id_404(self, restaurant, bad_restaurant, response):
+        """Prove that missing IDs are properly handled."""
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 404, content
@@ -479,3 +646,44 @@ class TestGetPropertyValue:
 
         message = exception.find("ows:ExceptionText", NAMESPACES).text
         assert message == "Feature not found with ID 0."
+
+
+@pytest.mark.django_db
+class TestGetPropertyValueWithPostRequest:
+    """All tests for the GetPropertyValue method."""
+
+    def test_get_feature_by_id_404(self, client, restaurant, bad_restaurant):
+        """Prove that missing IDs are properly handled."""
+        xml = f"""<GetPropertyValue service="WFS" version="2.0.0" valueReference="name"
+        storedQueryId="urn:ogc:def:query:OGC-WFS::GetFeatureById" id="restaurant.0"
+        {XML_NS}>
+        </GetPropertyValue>
+            """
+        response = client.post("/v1/wfs/", data=xml, content_type="application/xml")
+        content = read_response(response)
+        assert response["content-type"] == "text/xml; charset=utf-8", content
+        assert response.status_code == 404, content
+
+        xml_doc = validate_xsd(content, WFS_20_XSD)
+        assert xml_doc.attrib["version"] == "2.0.0"
+        exception = xml_doc.find("ows:Exception", NAMESPACES)
+        assert exception.attrib["exceptionCode"] == "NotFound"
+
+        message = exception.find("ows:ExceptionText", NAMESPACES).text
+        assert message == "Feature not found with ID 0."
+
+
+def _assert_filter(response, expect="Café Noir"):
+    content = read_response(response)
+    assert response["content-type"] == "text/xml; charset=utf-8", content
+    assert response.status_code == 200, content
+    assert "</wfs:ValueCollection>" in content
+
+    # Validate against the WFS 2.0 XSD
+    xml_doc = validate_xsd(content, WFS_20_XSD)
+    assert xml_doc.attrib["numberMatched"] == "1"
+    assert xml_doc.attrib["numberReturned"] == "1"
+
+    # Assert that the correct object was matched
+    name = xml_doc.find("wfs:member/app:name", namespaces=NAMESPACES).text
+    assert name == expect

--- a/tests/gisserver/views/test_liststoredqueries.py
+++ b/tests/gisserver/views/test_liststoredqueries.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.utils import WFS_20_XSD, assert_xml_equal, validate_xsd
+from tests.requests import Get, Post, parametrize_response
+from tests.utils import WFS_20_XSD, XML_NS, assert_xml_equal, validate_xsd
 
 # enable for all tests in this file
 pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
@@ -9,9 +10,12 @@ pytestmark = [pytest.mark.urls("tests.test_gisserver.urls")]
 class TestListStoredQueries:
     """All tests for the ListStoredQueries method."""
 
-    def test_get(self, client):
+    @parametrize_response(
+        Get("?SERVICE=WFS&REQUEST=ListStoredQueries&VERSION=2.0.0"),
+        Post(f'<ListStoredQueries version="2.0.0" service="WFS" {XML_NS}></ListStoredQueries>'),
+    )
+    def test_get(self, response):
         """Prove that the happy flow works"""
-        response = client.get("/v1/wfs/?SERVICE=WFS&REQUEST=ListStoredQueries&VERSION=2.0.0")
         content = response.content.decode()
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content

--- a/tests/requests.py
+++ b/tests/requests.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Optional, Union
+
+import pytest
+
+
+class Url(Enum):
+    NORMAL = "/v1/wfs/"
+    FLAT = "/v1/wfs-flattened/"
+    COMPLEX = "/v1/wfs-complextypes/"
+    GENERATED = "/v1/wfs-gen-field/"
+
+
+@dataclass
+class Request:
+    method: str
+    _url: Url
+    id: Optional[str]
+    expect: Optional[Any]
+
+    def __init__(self, *, id=None, expect=None, url: Url = Url.NORMAL):
+        self.id = id
+        self.expect = expect
+        self._url = url
+
+    def test_id(self):
+        if self.id:
+            return f"{self.method}-{self.id} ({self._url.name})"
+        return f"{self.method} ({self._url.name})"
+
+    @property
+    def url(self):
+        return self._url.value
+
+    @url.setter
+    def url(self, url: Url):
+        self._url = url
+
+
+@dataclass
+class Get(Request):
+    method = "GET"
+    query: Union[str, Callable]
+
+    def __init__(self, query, **kwargs):
+        super().__init__(**kwargs)
+        self.query = query
+
+
+@dataclass
+class Post(Request):
+    method = "POST"
+    body: Union[str, Callable]
+
+    def __init__(self, body, **kwargs):
+        super().__init__(**kwargs)
+        self.body = body
+
+
+# Decorator
+def parametrize_response(*param_values: Request, url: Optional[Url] = None):
+    """This is a decorator that wraps the parametrizing of "response", and allows us to
+    set global flags (used for getting the correct url).
+
+    Usage:
+    ```
+    @parametrize_response(
+        Get("?query=test"),
+        Get(lambda id: f"?query=test{id}", url=Url.COMPLEX),
+        Post("<xml></xml>"),
+        Post("<xml></xml>", expect=AssertionError),
+        url=Url.FLAT,
+    )
+    def test_function(response):
+        ...
+    ```
+
+    Note that each Request value can also take its own url, although you can also pass in
+    a global url as in the above example.
+
+    Requests (Get, Post) either get a string query/body argument or a Callable, which can be used
+    later in the testing function to perform different requests at different times in the test.
+    In this case, you need to call the response() to get an actual response object in your test.
+
+    NB: When your response depends on other fixtures (for example because you need to have
+    some rows in the database), ensure the `response` fixture argument comes at the end of the
+    testing function arguments.
+    """
+    for request in param_values:
+        if url and request.url == Url.NORMAL.value:
+            request.url = url
+
+    def decorator(func):
+        return pytest.mark.parametrize("response", param_values, indirect=True)(func)
+
+    return decorator

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,6 +30,8 @@ NAMESPACES = {
     "xsd": xmlns.xsd.value,
 }
 
+XML_NS = f'xmlns="{xmlns.wfs}" xmlns:fes="{xmlns.fes20}" xmlns:gml="{xmlns.gml32}"'
+
 # Additional coordinate reference systems
 RD_NEW = CRS.from_string("urn:ogc:def:crs:EPSG::28992")  # https://epsg.io/28992
 
@@ -130,3 +132,8 @@ def assert_xml_equal(got: bytes | str, want: str):
         example.want = want  # unencoded, avoid doctest for bytes type.
         message = checker.output_difference(example, got, PARSE_XML)
         raise AssertionError(message)
+
+
+def clean_filter_for_xml(xml):
+    """Removes leading <? xml ?> tag"""
+    return re.sub(r"<\?.*\?>", "", xml)


### PR DESCRIPTION
Dit zorgt voor ondersteuning van POST requests voor alle methods die we ook via GET ondersteunen. 

Daarnaast is een test helper gebouwd die het parametrizen van tests met verschillende urls/request methods eenvoudiger maakt. De bulk daarvan staat in `tests/requests.py`, een fixture en een helper om de test-ids goed te krijgen staan in `conftest.py`, misschien moeten we de boel consolideren. Het neigt enigszins naar library code, maar is nu nog flink gecoupled met deze usecase, wellicht kunnen we het op een bepaald moment lostrekken en een manier inbouwen om het te configureren, mocht het handig zijn om in andere repos deze code ook te gebruiken. 
Voor voorbeelden van hoe het gebruikt wordt zie de overige testfiles. 