### PR TITLE
Allow geometry field in relations, and allow GeneratedField

### DIFF
--- a/gisserver/db.py
+++ b/gisserver/db.py
@@ -143,7 +143,7 @@ def get_db_geometry_target(
     The path will be wrapped into a CRS Transform function if needed.
     """
     orm_path = gml_element.local_orm_path if use_relative_path else gml_element.orm_path
-    if gml_element.source.srid != output_crs.srid:
+    if gml_element.source_srid != output_crs.srid:
         return functions.Transform(orm_path, srid=output_crs.srid)
     else:
         return orm_path

--- a/gisserver/features.py
+++ b/gisserver/features.py
@@ -744,7 +744,7 @@ class FeatureType:
     def xsd_type(self) -> XsdComplexType:
         """Return the definition of this feature as an XSD Complex Type."""
         return self.xsd_type_class(
-            name=f"{self.name.title()}Type",
+            name=f"{self.name[0].upper()}{self.name[1:]}Type",
             elements=[field.xsd_element for field in self.fields],
             base=self.xsd_base_type,
             source=self.model,

--- a/gisserver/features.py
+++ b/gisserver/features.py
@@ -329,7 +329,7 @@ class ComplexFeatureField(FeatureField):
         model=None,
         abstract=None,
         xsd_class=None,
-        xsd_base_type=XsdTypes.gmlAbstractFeatureType,
+        xsd_base_type=None,
     ):
         """
         :param name: Name of the model field.

--- a/gisserver/features.py
+++ b/gisserver/features.py
@@ -141,7 +141,7 @@ def _get_model_fields(
                 feature_type=feature_type,
             )
             for f in model._meta.get_fields()
-            if not f.is_relation or f.many_to_one or f.one_to_one  # ForeignKey  # OneToOneField
+            if not f.is_relation or f.many_to_one or f.one_to_one  # ForeignKey, OneToOneField
         ]
     else:
         # Only defined fields
@@ -433,7 +433,7 @@ def field(
 class FeatureType:
     """Declare a feature that is exposed on the map.
 
-    All WFS operations use this class to read the feature ype.
+    All WFS operations use this class to read the feature type.
     You may subclass this class to provide extensions,
     such as redefining :meth:`get_queryset`.
 

--- a/gisserver/geometries.py
+++ b/gisserver/geometries.py
@@ -272,7 +272,7 @@ WGS84 = CRS.from_srid(4326)  # aka EPSG:4326
 
 @dataclass
 class BoundingBox:
-    """A bounding box that describes the extent of a map layer"""
+    """A bounding box (or "envelope") that describes the extent of a map layer"""
 
     south: Decimal  # longitude
     west: Decimal  # latitude

--- a/gisserver/output/base.py
+++ b/gisserver/output/base.py
@@ -50,7 +50,6 @@ class OutputRenderer:
         :param method: The calling WFS Method (e.g. GetFeature class)
         :param source_query: The query that generated this output.
         :param collection: The collected data for rendering.
-        :param projection: Which fields to render.
         :param output_crs: The requested output projection.
         """
         self.method = method

--- a/gisserver/output/geojson.py
+++ b/gisserver/output/geojson.py
@@ -137,7 +137,7 @@ class GeoJsonRenderer(OutputRenderer):
         return b'    {"type":"Feature","id":%b,%b"geometry":%b,"properties":%b}' % (
             orjson.dumps(f"{feature_type.name}.{instance.pk}"),
             json_geometry_name,
-            self.render_geometry(feature_type, instance),
+            self.render_geometry(projection, instance),
             orjson.dumps(properties, default=_json_default),
         )
 
@@ -150,11 +150,11 @@ class GeoJsonRenderer(OutputRenderer):
         else:
             return value
 
-    def render_geometry(self, feature_type, instance: models.Model) -> bytes:
+    def render_geometry(self, projection: FeatureProjection, instance: models.Model) -> bytes:
         """Generate the proper GeoJSON notation for a geometry.
         This calls the GDAL C-API rendering found in 'GEOSGeometry.json'
         """
-        geometry = getattr(instance, feature_type.geometry_field.name)
+        geometry = projection.get_main_geometry_value(instance)
         if geometry is None:
             return b"null"
 
@@ -227,7 +227,7 @@ class GeoJsonRenderer(OutputRenderer):
         """
         props = {}
         for xsd_element in xsd_elements:
-            if not xsd_element.is_geometry:
+            if not xsd_element.type.is_geometry:
                 value = xsd_element.get_value(instance)
                 if xsd_element.type.is_complex_type:
                     # Nested object data
@@ -278,10 +278,10 @@ class DBGeoJsonRenderer(GeoJsonRenderer):
 
         return queryset
 
-    def render_geometry(self, feature_type, instance: models.Model) -> bytes:
+    def render_geometry(self, projection: FeatureProjection, instance: models.Model) -> bytes:
         """Generate the proper GeoJSON notation for a geometry"""
         # Database server rendering
-        if not feature_type.geometry_fields:
+        if projection.main_geometry_element is None:
             return b"null"
 
         geojson = instance._as_db_geojson

--- a/gisserver/output/results.py
+++ b/gisserver/output/results.py
@@ -255,11 +255,10 @@ class SimpleFeatureCollection:
         # Start with an obviously invalid bbox,
         # which corrects at the first extend_to_geometry call.
         bbox = BoundingBox(math.inf, math.inf, -math.inf, -math.inf)
-        geometry_field = self.feature_type.resolve_element(
-            self.feature_type.geometry_field.name
-        ).child
+
+        # Allow the geometry to exist in a dotted relationship.
         for instance in self:
-            geometry_value = geometry_field.get_value(instance)
+            geometry_value = self.projection.get_main_geometry_value(instance)
             if geometry_value is None:
                 continue
 

--- a/gisserver/output/xmlschema.py
+++ b/gisserver/output/xmlschema.py
@@ -83,22 +83,19 @@ class XMLSchemaRenderer(OutputRenderer):
     def render_complex_type(self, complex_type: XsdComplexType):
         """Write the definition of a single class."""
         output = StringIO()
-        output.write(
-            f'  <complexType name="{complex_type.name}">\n'
-            "    <complexContent>\n"
-            f'      <extension base="{complex_type.base}">\n'
-            "        <sequence>\n"
-        )
+        output.write(f'  <complexType name="{complex_type.name}">\n    <complexContent>\n')
+        if complex_type.base is not None:
+            output.write(f'      <extension base="{complex_type.base}">\n')
+
+        output.write("        <sequence>\n")
 
         for xsd_element in complex_type.elements:
             output.write(f"          {xsd_element}\n")
 
-        output.write(
-            "        </sequence>\n"
-            "      </extension>\n"
-            "    </complexContent>\n"
-            "  </complexType>\n\n"
-        )
+        output.write("        </sequence>\n")
+        if complex_type.base is not None:
+            output.write("      </extension>\n")
+        output.write("    </complexContent>\n  </complexType>\n\n")
         return output.getvalue()
 
     def _get_complex_types(self, root: XsdComplexType) -> Iterable[XsdComplexType]:

--- a/gisserver/parsers/fes20/operators.py
+++ b/gisserver/parsers/fes20/operators.py
@@ -265,7 +265,7 @@ class NonIdOperator(Operator):
             tag = self._source if self._source is not None else None
 
             # e.g. deny <PropertyIsLessThanOrEqualTo> against <gml:boundedBy>
-            if xsd_element.is_geometry and not self.allow_geometries:
+            if xsd_element.type.is_geometry and not self.allow_geometries:
                 raise OperationProcessingFailed(
                     f"Operator '{tag}' does not support comparing"
                     f" geometry properties: '{xsd_element.xml_name}'.",
@@ -401,7 +401,7 @@ class BinarySpatialOperator(SpatialOperator):
     def build_query(self, compiler: CompiledQuery) -> Q:
         operant1 = self.operand1
         if operant1 is None:
-            operant1 = ValueReference(xpath=compiler.feature_type.geometry_field.name)
+            operant1 = ValueReference(xpath=compiler.feature_type.main_geometry_element.orm_path)
 
         return self.build_compare(
             compiler,

--- a/gisserver/parsers/fes20/query.py
+++ b/gisserver/parsers/fes20/query.py
@@ -6,6 +6,7 @@ from functools import reduce
 from django.conf import settings
 from django.contrib.gis.db.models.fields import BaseSpatialField
 from django.contrib.gis.db.models.lookups import DWithinLookup
+from django.core.exceptions import FieldError
 from django.db import models
 from django.db.models import Q, QuerySet, lookups
 from django.db.models.expressions import Combinable
@@ -150,7 +151,11 @@ class CompiledQuery:
             pass
 
         if lookups:
-            queryset = queryset.filter(*lookups)
+            try:
+                queryset = queryset.filter(*lookups)
+            except FieldError as e:
+                e.args = (f"{e.args[0]} Constructed query: {lookups!r}",) + e.args[1:]
+                raise
 
         if self.ordering:
             queryset = queryset.order_by(*self.ordering)

--- a/gisserver/queries/adhoc.py
+++ b/gisserver/queries/adhoc.py
@@ -172,7 +172,7 @@ class AdhocQuery(QueryExpression):
             # that only partially exist within the bbox
             lookup = operators.SpatialOperatorName.BBOX.value  # "intersects"
             filters = {
-                f"{feature_type.geometry_field.name}__{lookup}": self.bbox.as_polygon(),
+                f"{feature_type.main_geometry_element.orm_path}__{lookup}": self.bbox.as_polygon(),
             }
             compiler.add_lookups(Q(**filters))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,13 @@ from psycopg2 import Binary
 from gisserver import conf
 from gisserver.types import GML32
 from tests.constants import RD_NEW, RD_NEW_SRID
-from tests.test_gisserver.models import City, OpeningHour, Restaurant, current_datetime
+from tests.test_gisserver.models import (
+    City,
+    OpeningHour,
+    Restaurant,
+    RestaurantReview,
+    current_datetime,
+)
 from tests.utils import read_json
 from tests.xsd_download import download_schema
 
@@ -57,6 +63,11 @@ class CoordinateInputs:
     point2_ewkt: str
     point2_geojson: list[Decimal]
     point2_xml_wgs84: str
+
+    @property
+    def bbox(self) -> str:
+        """Provide an extent in which both coordinates exist."""
+        return ",".join(map(str, (self.point1_wgs84 | self.point2_wgs84).extent))
 
 
 def _get_point(hex_ewkb: str) -> Point:
@@ -194,6 +205,16 @@ def bad_restaurant() -> Restaurant:
         is_open=False,
         created=current_datetime() + timedelta(hours=8),
     )
+
+
+@pytest.fixture()
+def restaurant_review(restaurant) -> RestaurantReview:
+    return RestaurantReview.objects.create(restaurant=restaurant, review="Pretty good!")
+
+
+@pytest.fixture()
+def bad_restaurant_review(bad_restaurant) -> RestaurantReview:
+    return RestaurantReview.objects.create(restaurant=bad_restaurant, review="Stay away!")
 
 
 @pytest.fixture(scope="session")

--- a/tests/gisserver/test_features.py
+++ b/tests/gisserver/test_features.py
@@ -1,0 +1,86 @@
+import django
+import pytest
+
+from gisserver.features import FeatureField, FeatureType
+from gisserver.types import GmlElement, XsdElement, XsdTypes
+from tests.test_gisserver import models
+
+
+class TestFeatureField:
+    """Prove that the FeatureField code will generate the expected XML type."""
+
+    @pytest.mark.parametrize(
+        "field_name,cls_type,xsd_type,xml",
+        [
+            (
+                "name",
+                XsdElement,
+                XsdTypes.string,
+                '<element name="name" type="string" minOccurs="0" />',
+            ),
+            (
+                "location",
+                GmlElement,
+                XsdTypes.gmlPointPropertyType,
+                '<element name="location" type="gml:PointPropertyType" minOccurs="0" maxOccurs="1" nillable="true" />',
+            ),
+        ],
+    )
+    def test_as_xml(self, field_name, cls_type, xsd_type, xml):
+        ff = FeatureField(field_name, model_attribute=field_name, model=models.Restaurant)
+        assert ff.xsd_element.as_xml == xml
+        assert ff.xsd_element.type == xsd_type
+        assert isinstance(ff.xsd_element, cls_type)
+
+
+@pytest.mark.skipif(
+    django.VERSION < (5, 0), reason="GeneratedField is only available in Django >= 5"
+)
+class TestGeneratedFields:
+    @pytest.mark.parametrize(
+        "field_name,type,xml",
+        [
+            # GeneratedField that outputs a CharField
+            (
+                "name_reversed",
+                XsdTypes.string,
+                '<element name="name_reversed" type="string" minOccurs="0" />',
+            ),
+            # GeneratedField that outputs a PointField
+            (
+                "geometry_translated",
+                XsdTypes.gmlPointPropertyType,
+                '<element name="geometry_translated" type="gml:PointPropertyType" minOccurs="0" maxOccurs="1" />',
+            ),
+        ],
+    )
+    def test_generated_field_is_resolved_correctly(self, field_name, type, xml):
+        ff = FeatureField(
+            field_name, model_attribute=field_name, model=models.ModelWithGeneratedFields
+        )
+        assert ff.xsd_element.as_xml == xml
+        assert ff.xsd_element.type == type
+
+    def test_generated_geometry_field(self):
+        """Prove that both geometry and generated field are included as geometry field."""
+        ft = FeatureType(
+            models.ModelWithGeneratedFields.objects.all(),
+            fields=["name", "name_reversed", "geometry", "geometry_translated"],
+            geometry_field_name="geometry_translated",
+        )
+
+        # The geometry_fields attribute should include both geo fields
+        geo_fields = [e.name for e in ft.all_geometry_elements]
+        assert geo_fields == ["geometry", "geometry_translated"]
+
+        model_fields = [e.source for e in ft.all_geometry_elements]
+        assert model_fields == [
+            models.ModelWithGeneratedFields.geometry.field,
+            models.ModelWithGeneratedFields.geometry_translated.field,
+        ]
+
+        # There should be a main geometry_field, which refers to the GeneratedField
+        assert ft.main_geometry_element.name == "geometry_translated"
+        assert ft.main_geometry_element.orm_path == "geometry_translated"
+        assert ft.main_geometry_element.source_srid == 4326
+        assert ft.main_geometry_element.type.is_geometry

--- a/tests/gisserver/views/input.py
+++ b/tests/gisserver/views/input.py
@@ -395,3 +395,34 @@ SORT_BY = {
     "rating-desc": ("rating DESC", ["Café Noir", "Foo Bar"]),
     "rating,name-asc": ("rating,name ASC", ["Foo Bar", "Café Noir"]),
 }
+
+GENERATED_FIELD_FILTER = {
+    "name_reversed": (
+        """
+        <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.opengis.net/fes/2.0
+                http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+            <fes:PropertyIsEqualTo>
+                <fes:ValueReference>name_reversed</fes:ValueReference>
+                <fes:Literal>emordnilaP</fes:Literal>
+            </fes:PropertyIsEqualTo>
+        </fes:Filter>
+        """
+    ),
+    "geometry_translated": (
+        # geometry_translated =~ 5.90876 53.36317
+        """
+        <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+            <fes:BBOX>
+                <fes:ValueReference>geometry_translated</fes:ValueReference>
+                <gml:Envelope xmlns:gml="http://www.opengis.net/gml/3.2"
+                              srsName="urn:ogc:def:crs:EPSG::4326">
+                    <gml:lowerCorner>5.7 53.1</gml:lowerCorner>
+                    <gml:upperCorner>6.1 53.5</gml:upperCorner>
+                </gml:Envelope>
+            </fes:BBOX>
+        </fes:Filter>
+        """
+    ),
+}

--- a/tests/gisserver/views/test_describefeaturetype.py
+++ b/tests/gisserver/views/test_describefeaturetype.py
@@ -126,24 +126,20 @@ class TestDescribeFeatureType:
 
   <complexType name="CityType">
     <complexContent>
-      <extension base="gml:AbstractFeatureType">
-        <sequence>
-          <element name="id" type="integer" minOccurs="0" />
-          <element name="name" type="string" minOccurs="0" />
-        </sequence>
-      </extension>
+      <sequence>
+        <element name="id" type="integer" minOccurs="0" />
+        <element name="name" type="string" minOccurs="0" />
+      </sequence>
     </complexContent>
   </complexType>
 
   <complexType name="OpeningHourType">
     <complexContent>
-      <extension base="gml:AbstractFeatureType">
-        <sequence>
-          <element name="weekday" type="integer" minOccurs="0" />
-          <element name="start_time" type="time" minOccurs="0" />
-          <element name="end_time" type="time" minOccurs="0" />
-        </sequence>
-      </extension>
+      <sequence>
+        <element name="weekday" type="integer" minOccurs="0" />
+        <element name="start_time" type="time" minOccurs="0" />
+        <element name="end_time" type="time" minOccurs="0" />
+      </sequence>
     </complexContent>
   </complexType>
 

--- a/tests/gisserver/views/test_describefeaturetype.py
+++ b/tests/gisserver/views/test_describefeaturetype.py
@@ -1,5 +1,6 @@
 import urllib.parse
 
+import django
 import pytest
 from lxml import etree
 
@@ -69,6 +70,67 @@ class TestDescribeFeatureType:
           <element name="is_open" type="boolean" minOccurs="0" />
           <element name="created" type="dateTime" minOccurs="0" />
           <element name="tags" type="string" minOccurs="0" maxOccurs="unbounded" nillable="true" />
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>""",  # noqa: E501
+        )
+
+    @pytest.mark.skipif(
+        django.VERSION < (5, 0), reason="GeneratedField is only available in Django >= 5"
+    )
+    def test_describe_generated_field(self, client):
+        """Prove that the happy flow works"""
+        response = client.get(
+            "/v1/wfs-gen-field/?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=modelwithgeneratedfields"
+        )
+        content = response.content.decode()
+        assert response["content-type"] == "application/gml+xml; version=3.2", content
+        assert response.status_code == 200, content
+        assert "PropertyType" in content  # for element holding a GML field
+
+        # The response is an XSD itself.
+        # Only validate its XML structure
+        xml_doc: etree._Element = etree.fromstring(response.content)
+        assert xml_doc.tag == "{http://www.w3.org/2001/XMLSchema}schema"
+        elements = xml_doc.findall(
+            "xsd:complexType/xsd:complexContent/xsd:extension/xsd:sequence/xsd:element",
+            namespaces=NAMESPACES,
+        )
+        field_names = [el.attrib["name"] for el in elements]
+        assert field_names == [
+            "id",
+            "name",
+            "name_reversed",
+            "geometry",
+            "geometry_translated",
+        ]
+
+        assert_xml_equal(
+            response.content,
+            """<schema
+   targetNamespace="http://example.org/gisserver"
+   xmlns:app="http://example.org/gisserver"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns="http://www.w3.org/2001/XMLSchema"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   elementFormDefault="qualified" version="0.1">
+
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+  <element name="modelwithgeneratedfields" type="app:ModelwithgeneratedfieldsType" substitutionGroup="gml:AbstractFeature" />
+
+  <complexType name="ModelwithgeneratedfieldsType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="id" type="integer" minOccurs="0" />
+          <element name="name" type="string" minOccurs="0" />
+          <element name="name_reversed" type="string" minOccurs="0" />
+          <element name="geometry" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+          <element name="geometry_translated" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
         </sequence>
       </extension>
     </complexContent>

--- a/tests/gisserver/views/test_getfeature_gml.py
+++ b/tests/gisserver/views/test_getfeature_gml.py
@@ -528,7 +528,6 @@ class TestGetFeature:
         xml_doc = validate_xsd(content, WFS_20_XSD)
         timestamp = xml_doc.attrib["timeStamp"]
 
-        print(content.decode("utf-8"))
         assert_xml_equal(
             content,
             f"""<wfs:FeatureCollection

--- a/tests/gisserver/views/test_getfeature_stored.py
+++ b/tests/gisserver/views/test_getfeature_stored.py
@@ -58,7 +58,7 @@ class TestGetFeature:
     <app:name>Café Noir</app:name>
     <app:city_id>{restaurant.city_id}</app:city_id>
     <app:location>
-        <gml:Point gml:id="restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::4326">
+        <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::4326">
             <gml:pos srsDimension="2">{coordinates.point1_xml_wgs84}</gml:pos>
         </gml:Point>
     </app:location>

--- a/tests/gisserver/views/test_getpropertyvalue.py
+++ b/tests/gisserver/views/test_getpropertyvalue.py
@@ -89,7 +89,7 @@ class TestGetPropertyValue:
        timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
   <wfs:member>
     <app:location>
-      <gml:Point gml:id="restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::4326">
+      <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::4326">
         <gml:pos srsDimension="2">{coordinates.point1_xml_wgs84}</gml:pos>
       </gml:Point>
     </app:location>

--- a/tests/gisserver/views/test_propertyname.py
+++ b/tests/gisserver/views/test_propertyname.py
@@ -179,6 +179,7 @@ class TestPropertyName:
                 ' INNER JOIN "test_gisserver_restaurant_opening_hours"'
                 ' ON ("test_gisserver_openinghour"."id" = "test_gisserver_restaurant_opening_hours"."openinghour_id")'
                 f' WHERE "test_gisserver_restaurant_opening_hours"."restaurant_id" IN ({restaurant_m2m.id}, {bad_restaurant.id})'
+                ' ORDER BY "test_gisserver_openinghour"."weekday" ASC'
             ),
         ]
 
@@ -377,6 +378,7 @@ class TestPropertyName:
                 ' INNER JOIN "test_gisserver_restaurant_opening_hours"'
                 ' ON ("test_gisserver_openinghour"."id" = "test_gisserver_restaurant_opening_hours"."openinghour_id")'
                 f' WHERE "test_gisserver_restaurant_opening_hours"."restaurant_id" IN ({restaurant_m2m.id}, {bad_restaurant.id})'
+                ' ORDER BY "test_gisserver_openinghour"."weekday" ASC'
             ),
         ]
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,6 +21,24 @@ INSTALLED_APPS = [
     "django.contrib.postgres",
 ]
 
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "level": "DEBUG",
+        "handlers": ["console"],
+    },
+    "loggers": {
+        "django": {"handlers": ["console"], "level": "INFO", "propagate": False},
+    },
+}
+
 # Test session requirements
 
 SECRET_KEY = "insecure-tests-only"

--- a/tests/test_gisserver/models.py
+++ b/tests/test_gisserver/models.py
@@ -24,6 +24,9 @@ class OpeningHour(models.Model):
     start_time = models.TimeField(default=time(16, 0))
     end_time = models.TimeField(default=time(23, 30))
 
+    class Meta:
+        ordering = ("weekday",)
+
     def __str__(self):
         return f"{self.get_weekday_display()}: {self.start_time} - {self.end_time}"
 

--- a/tests/test_gisserver/models.py
+++ b/tests/test_gisserver/models.py
@@ -2,6 +2,7 @@ import calendar
 from datetime import datetime, time, timezone
 
 from django.contrib.gis.db.models import PointField
+from django.contrib.gis.db.models.functions import Translate
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
@@ -59,3 +60,29 @@ class RestaurantReview(models.Model):
 
     def __str__(self):
         return f"{self.restaurant}: {self.review}"
+
+
+if hasattr(models, "GeneratedField"):
+    # Only available in Django 5 and later.
+
+    class ModelWithGeneratedFields(models.Model):
+        name = models.CharField(max_length=20)
+        name_reversed = models.GeneratedField(
+            expression=models.functions.Reverse("name"),
+            output_field=models.CharField(max_length=20),
+            db_persist=True,
+        )
+
+        geometry = PointField(null=True)
+
+        geometry_translated = models.GeneratedField(
+            expression=Translate("geometry", x=1, y=1),
+            output_field=PointField(null=True),
+            db_persist=True,
+        )
+
+        class Meta:
+            ordering = ["id"]  # for test result consistency
+
+        def __str__(self):
+            return self.name

--- a/tests/test_gisserver/models.py
+++ b/tests/test_gisserver/models.py
@@ -47,3 +47,15 @@ class Restaurant(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class RestaurantReview(models.Model):
+    """A model whose geometry exists in another model.
+    Can both be used to test reverse relations OR to test geometries on a related model.
+    """
+
+    restaurant = models.ForeignKey(Restaurant, on_delete=models.CASCADE, related_name="reviews")
+    review = models.TextField()
+
+    def __str__(self):
+        return f"{self.restaurant}: {self.review}"

--- a/tests/test_gisserver/urls.py
+++ b/tests/test_gisserver/urls.py
@@ -1,3 +1,4 @@
+import django
 from django.urls import path
 
 from . import views
@@ -20,3 +21,12 @@ urlpatterns = [
         name="wfs-view-relatedgeometry",
     ),
 ]
+
+if django.VERSION >= (5, 0):
+    urlpatterns += [
+        path(
+            "v1/wfs-gen-field/",
+            views.GeneratedFieldWFSView.as_view(),
+            name="wfs-generated-fields",
+        ),
+    ]

--- a/tests/test_gisserver/urls.py
+++ b/tests/test_gisserver/urls.py
@@ -14,4 +14,9 @@ urlpatterns = [
         views.FlattenedWFSView.as_view(),
         name="wfs-view-flattened",
     ),
+    path(
+        "v1/wfs-related-geometry/",
+        views.RelatedGeometryWFSView.as_view(),
+        name="wfs-view-relatedgeometry",
+    ),
 ]


### PR DESCRIPTION
This needed a refactor to further remove the dependency on model field data, and moves all logic into the XSD element structure/definitions.

To understand the diff:

* All logic for geometry handling moved to the XSD type detection.
* The `orm_path` attribute was sometimes absolute, sometimes relative. These are all absolute paths now.
* CSV rendering relied on select_related(), but that can't receive annotations (e.g. `AsEWKT()`). Now using prefetch_related there.
* Complete rewrote `gisserver.db` to make accessing database-rendered geometries easier.
* For clarity between the different layers of the application (FeatureType definitions / XSD definitions / FeatureProjection), some properties have been renamed for consistency between these.
* Since more code depends on XSD definitions instead of the "main_geometry_field", it became easier to support GeneratedField class from Django 5 later.