### PR TITLE
Improve error handling (tested with QGis)

### DIFF
--- a/gisserver/locale/nl/LC_MESSAGES/django.po
+++ b/gisserver/locale/nl/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-#: gisserver/templates/gisserver/index.html:12
+#: gisserver/templates/gisserver/index.html:13
 msgid "WFS Feature Types"
 msgstr "WFS feature types"
 
@@ -23,29 +23,38 @@ msgid "Add the following URL to your GIS application:"
 msgstr "Voeg de volgende URL aan je GIS applicatie toe:"
 
 #: gisserver/templates/gisserver/wfs/feature_type.html:11
-msgid "Namespace"
-msgstr ""
+msgid "XML Namespace"
+msgstr "XML Naamruimte"
 
 #: gisserver/templates/gisserver/wfs/feature_type.html:12
 msgid "Typename"
 msgstr "Typename"
 
-#: gisserver/templates/gisserver/wfs/feature_type.html:14
+#: gisserver/templates/gisserver/wfs/feature_type.html:13
+msgid "Supported CRS"
+msgstr "Ondersteunde CRS"
+
+#: gisserver/templates/gisserver/wfs/feature_type.html:16
+#, python-format
+msgid "Any CRS value is supported, source data uses %(default_crs)s."
+msgstr "Alle CRS waarden worden ondersteund, de brongegevens gebruiken %(default_crs)s."
+
+#: gisserver/templates/gisserver/wfs/feature_type.html:22
 msgid "Formats"
 msgstr "Formaten"
 
-#: gisserver/templates/gisserver/wfs/feature_type.html:28
+#: gisserver/templates/gisserver/wfs/feature_type.html:36
 msgid "The following fields are available:"
 msgstr "De volgende velden zijn beschikbaar:"
 
-#: gisserver/templates/gisserver/wfs/feature_type.html:30
+#: gisserver/templates/gisserver/wfs/feature_type.html:38
 msgid "Field Name"
 msgstr "Veldnaam"
 
-#: gisserver/templates/gisserver/wfs/feature_type.html:30
+#: gisserver/templates/gisserver/wfs/feature_type.html:38
 msgid "Type"
 msgstr "Type"
 
-#: gisserver/templates/gisserver/wfs/feature_type.html:30
+#: gisserver/templates/gisserver/wfs/feature_type.html:38
 msgid "Description"
 msgstr "Omschrijving"

--- a/gisserver/management/commands/loadgeojson.py
+++ b/gisserver/management/commands/loadgeojson.py
@@ -264,8 +264,16 @@ class Command(BaseCommand):
             }
 
             # Store the geometry, note GEOS only parses stringified JSON.
-            geometry = GEOSGeometry(json.dumps(geometry_data), srid=self.crs.srid)
-            geometry.srid = self.crs.srid  # override default
+            if geometry_data is None:
+                geometry = None
+            else:
+                try:
+                    geometry = GEOSGeometry(json.dumps(geometry_data), srid=self.crs.srid)
+                except ValueError as e:
+                    raise CommandError(
+                        f"Unable to parse geometry data: {geometry_data!r}: {e}"
+                    ) from e
+                geometry.srid = self.crs.srid  # override default
             field_values[main_geometry_field] = geometry
 
             # Try to decode the identifier if it's present

--- a/gisserver/management/commands/loadgeojson.py
+++ b/gisserver/management/commands/loadgeojson.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "-f",
             "--field",
-            nargs="*",
+            action="append",
             dest="map_fields",
             type=_parse_fields,
             metavar="NAME=FIELD",

--- a/gisserver/management/commands/loadgeojson.py
+++ b/gisserver/management/commands/loadgeojson.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import operator
+from argparse import ArgumentTypeError
 from functools import reduce
 from itertools import islice
 from urllib.request import urlopen
@@ -22,15 +23,15 @@ def _parse_model(value):
     try:
         return apps.get_model(value)
     except LookupError as e:
-        raise ValueError(str(e)) from e
+        raise ArgumentTypeError(str(e)) from e
 
 
 def _parse_fields(value):
     field_map = {}
     for pair in value.split(","):
         geojson_name, _, field_name = pair.strip().partition("=")
-        if not value:
-            raise ValueError("Expect property=field,property2=field2 format")
+        if not field_name:
+            raise ArgumentTypeError("Expect property=field,property2=field2 format")
         field_map[geojson_name] = field_name
     return field_map
 

--- a/gisserver/output/csv.py
+++ b/gisserver/output/csv.py
@@ -66,7 +66,7 @@ class CSVRenderer(CollectionOutputRenderer):
             writer.writerow(self.get_header(projection, xsd_elements))
 
             # Write all rows
-            for instance in sub_collection:
+            for instance in self.read_features(sub_collection):
                 writer.writerow(self.get_row(instance, projection, xsd_elements))
 
                 # Only perform a 'yield' every once in a while,

--- a/gisserver/output/geojson.py
+++ b/gisserver/output/geojson.py
@@ -84,7 +84,7 @@ class GeoJsonRenderer(CollectionOutputRenderer):
                 output.write(b",\n")
 
             is_first = True
-            for instance in sub_collection:
+            for instance in self.read_features(sub_collection):
                 if is_first:
                     is_first = False
                 else:

--- a/gisserver/parsers/fes20/operators.py
+++ b/gisserver/parsers/fes20/operators.py
@@ -303,14 +303,14 @@ class NonIdOperator(Operator):
         For example, comparisons like ``name == "test"`` are fine,
         but ``geometry < 4`` or ``datefield == 35.2" raise an error.
 
-        The lhs/rhs are expected to be ordered in a logical sequence.
-        So ``<value> == <element>`` should be provided as ``<element> == <value>``.
-
         :param compiler: The object that holds the intermediate state
         :param lhs: The left-hand-side of the comparison (e.g. the element).
         :param lookup: The ORM lookup expression being used (e.g. ``equals`` or ``fes_like``).
         :param rhs: The right-hand-side of the comparison (e.g. the value).
         """
+        if isinstance(lhs, Literal) and isinstance(rhs, ValueReference):
+            lhs, rhs = rhs, lhs
+
         if isinstance(lhs, ValueReference):
             xsd_element = lhs.parse_xpath(compiler.feature_types).child
             tag = self._source if self._source is not None else None

--- a/gisserver/parsers/fes20/sorting.py
+++ b/gisserver/parsers/fes20/sorting.py
@@ -60,7 +60,7 @@ class SortProperty(BaseNode):
 
     @classmethod
     @expect_tag(xmlns.fes20, "SortProperty")
-    @expect_children(1, ValueReference, "SortOrder")
+    @expect_children(1, ValueReference, FES_SORT_ORDER)
     def from_xml(cls, element: NSElement) -> SortProperty:
         """Parse the incoming XML"""
         sort_order = element.find(FES_SORT_ORDER)
@@ -108,7 +108,7 @@ class SortBy(BaseNode):
     sort_properties: list[SortProperty]
 
     @classmethod
-    @expect_children(1)
+    @expect_children(1, SortProperty)
     def from_xml(cls, element: NSElement) -> SortBy:
         """Parse the XML tag."""
         return cls(

--- a/gisserver/parsers/query.py
+++ b/gisserver/parsers/query.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import operator
 from datetime import date, datetime
+from decimal import Decimal as D
 from functools import reduce
 from typing import Union
 
@@ -16,7 +17,8 @@ from django.db.models.expressions import Combinable, Func
 from gisserver.features import FeatureType
 
 logger = logging.getLogger(__name__)
-RhsTypes = Union[Combinable, Func, Q, GEOSGeometry, bool, int, str, date, datetime, tuple]
+ScalarTypes = (bool, int, str, D, date, datetime)  # Not Union for Python 3.9
+RhsTypes = Union[Combinable, Func, Q, GEOSGeometry, bool, int, D, str, date, datetime, tuple]
 
 
 class CompiledQuery:

--- a/gisserver/parsers/values.py
+++ b/gisserver/parsers/values.py
@@ -13,6 +13,9 @@ RE_FLOAT = re.compile(r"\A[0-9]+(\.[0-9]+)\Z")
 
 def auto_cast(value: str):
     """Automatically cast a value to a scalar."""
+    if not isinstance(value, str):
+        return value
+
     if value.isdigit():
         return int(value)
     elif RE_FLOAT.match(value):

--- a/gisserver/parsers/xml.py
+++ b/gisserver/parsers/xml.py
@@ -108,6 +108,16 @@ class NSElement(Element):
         """Resolve an aliased QName value to its fully qualified name."""
         return parse_qname(qname, self.ns_aliases)
 
+    @property
+    def qname(self) -> str:
+        """Provde the tag name in its original short format"""
+        ns, localname = split_ns(self.tag)
+        if ns:
+            for prefix, full_ns in self.ns_aliases.items():
+                if full_ns == ns:
+                    return f"{prefix}:{localname}"
+        return localname
+
     def get_str_attribute(self, name: str) -> str:
         """Resolve an attribute, raise an error when it's missing."""
         try:

--- a/gisserver/templates/gisserver/index.html
+++ b/gisserver/templates/gisserver/index.html
@@ -1,3 +1,4 @@
+
 {% extends "gisserver/base.html" %}{% load i18n %}
 
 {% block title %}{{ service_description.title }} {{ accept_operations|dictsort:0|join:"/" }}{% endblock %}

--- a/gisserver/templates/gisserver/service_description.html
+++ b/gisserver/templates/gisserver/service_description.html
@@ -2,13 +2,19 @@
 <h1>{{ service_description.title }} {{ accept_operations|dictsort:0|join:"/" }}</h1>
 {% if service_description.abstract %}{{ service_description.abstract|linebreaks }}{% endif %}
 
+{% if service_description.keywords or service_description.provider_name %}
+<dl>
 {% if service_description.keywords %}
-<p>{% translate "Keywords" %}: {{ service_description.keywords|join:", " }}</p>
+<dt>{% translate "Keywords" %}:</dt><dd>{{ service_description.keywords|join:", " }}</dd>
 {% endif %}
 {% if service_description.provider_name %}
-  <p>{% translate "Provider" %}: {% if service_description.provider_site %}<a href="{{ service_description.provider_site }}">{% endif %}{{ service_description.provider_name }}{% if service_description.provider_site %}</a></p>{% endif %}
-  {% if service_description.contact_person %}<p>{% translate "Contact" %}: {{ service_description.contact_person }}</p>{% endif %}
+  <dt>{% translate "Provider" %}:</dt>
+  <dd>{% if service_description.provider_site %}<a href="{{ service_description.provider_site }}">{% endif %}{{ service_description.provider_name }}{% if service_description.provider_site %}</a></dd>{% endif %}
+  {% if service_description.contact_person %}<dt>{% translate "Contact" %}:</dt><dd>{{ service_description.contact_person }}</dd>{% endif %}
 {% endif %}
+</dl>
+{% endif %}
+
 {% if connect_url %}
 <h2>{% translate "Using This WFS" %}</h2>
 <p>{% translate "Add the following URL to your GIS application:" %}</p>

--- a/gisserver/templates/gisserver/wfs/feature_type.html
+++ b/gisserver/templates/gisserver/wfs/feature_type.html
@@ -8,8 +8,16 @@
 {% block metadata %}
   <dl>
   {% block metadata-items %}
-    <dt>{% translate "Namespace" %}:</dt><dd><code>{{ feature_type.xml_namespace }}</code></dd>
+    <dt>{% translate "XML Namespace" %}:</dt><dd><code>{{ feature_type.xml_namespace }}</code></dd>
     <dt>{% translate "Typename" %}:</dt><dd><abbr title="{{ feature_type.xml_name }}">{% feature_qname feature_type %}</abbr></dd>
+    <dt>{% translate "Supported CRS" %}:</dt>
+    <dd>
+      {% if GISSERVER_SUPPORTED_CRS_ONLY %}
+        {% blocktranslate with default_crs=feature_type.crs %}Any CRS value is supported, source data uses {{ default_crs }}.{% endblocktranslate %}
+      {% else %}
+        {{ feature_type.supported_crs|join:", " }}
+      {% endif %}
+    </dd>
     {% if wfs_output_formats %}
       <dt>{% translate "Formats" %}:</dt>
       <dd>{% block metadata-formats %}

--- a/gisserver/views.py
+++ b/gisserver/views.py
@@ -422,6 +422,7 @@ class WFSView(OWSView):
         context = super().get_index_context_data(**kwargs)
         context.update(
             {
+                "GISSERVER_SUPPORTED_CRS_ONLY": conf.GISSERVER_SUPPORTED_CRS_ONLY,
                 "wfs_features": self.get_bound_feature_types(),
                 "wfs_output_formats": self._get_wfs_output_formats(),
                 "wfs_filter_capabilities": self.wfs_filter_capabilities,

--- a/tests/gisserver/parsers/fes20/test_bad_input.py
+++ b/tests/gisserver/parsers/fes20/test_bad_input.py
@@ -59,16 +59,9 @@ def test_missing_children():
         Filter.from_string(xml_text)
 
     assert str(e.value) == (
-        "<{http://www.opengis.net/fes/2.0}PropertyIsLessThan> should have 2 child nodes, got 1 "
-        "(possible tags:"
-        " {http://www.opengis.net/fes/2.0}Add,"
-        " {http://www.opengis.net/fes/2.0}Div,"
-        " {http://www.opengis.net/fes/2.0}Function,"
-        " {http://www.opengis.net/fes/2.0}Literal,"
-        " {http://www.opengis.net/fes/2.0}Mul,"
-        " {http://www.opengis.net/fes/2.0}Sub,"
-        " {http://www.opengis.net/fes/2.0}ValueReference"
-        ")"
+        "<fes:PropertyIsLessThan> should have 2 child nodes, got only 1. "
+        "Allowed types are: <fes:Add>, <fes:Div>, <fes:Function>, <fes:Literal>, <fes:Mul>,"
+        " <fes:Sub>, <fes:ValueReference>."
     )
 
 
@@ -93,28 +86,39 @@ def test_missing_children_operator():
         Filter.from_string(xml_text)
 
     assert str(e.value) == (
-        "<{http://www.opengis.net/fes/2.0}And> should have 2 child nodes, got 1 "
-        "(possible tags: {http://www.opengis.net/fes/2.0}BBOX, "
-        "{http://www.opengis.net/fes/2.0}Beyond, "
-        "{http://www.opengis.net/fes/2.0}Contains, "
-        "{http://www.opengis.net/fes/2.0}Crosses, "
-        "{http://www.opengis.net/fes/2.0}DWithin, "
-        "{http://www.opengis.net/fes/2.0}Disjoint, "
-        "{http://www.opengis.net/fes/2.0}Equals, "
-        "{http://www.opengis.net/fes/2.0}Intersects, "
-        "{http://www.opengis.net/fes/2.0}Overlaps, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsBetween, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsEqualTo, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsGreaterThan, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsGreaterThanOrEqualTo, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsLessThan, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsLessThanOrEqualTo, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsLike, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsNil, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsNotEqualTo, "
-        "{http://www.opengis.net/fes/2.0}PropertyIsNull, "
-        "{http://www.opengis.net/fes/2.0}Touches, "
-        "{http://www.opengis.net/fes/2.0}Within)"
+        "<fes:And> should have 2 child nodes, got only 1. Allowed types are: "
+        "<fes:And>, <fes:BBOX>, <fes:Beyond>, <fes:Contains>, <fes:Crosses>, "
+        "<fes:DWithin>, <fes:Disjoint>, <fes:Equals>, <fes:Intersects>, <fes:Not>, "
+        "<fes:Or>, <fes:Overlaps>, <fes:PropertyIsBetween>, <fes:PropertyIsEqualTo>, "
+        "<fes:PropertyIsGreaterThan>, <fes:PropertyIsGreaterThanOrEqualTo>, "
+        "<fes:PropertyIsLessThan>, <fes:PropertyIsLessThanOrEqualTo>, "
+        "<fes:PropertyIsLike>, <fes:PropertyIsNil>, <fes:PropertyIsNotEqualTo>, "
+        "<fes:PropertyIsNull>, <fes:Touches>, <fes:Within>."
+    )
+
+
+def test_invalid_children():
+    """See that get_tag_names() walks through the class hierarchy to
+    provide all possible tag names.
+    """
+    xml_text = """
+        <fes:Filter
+            xmlns:fes="http://www.opengis.net/fes/2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <fes:PropertyIsLessThan>
+                <fes:Filter></fes:Filter>
+                <fes:SortBy></fes:SortBy>
+            </fes:PropertyIsLessThan>
+        </fes:Filter>
+    """.strip()
+
+    with pytest.raises(ExternalParsingError) as e:
+        Filter.from_string(xml_text)
+
+    assert str(e.value) == (
+        "<fes:PropertyIsLessThan> does not support a <fes:Filter> child node. Allowed "
+        "types are: <fes:Add>, <fes:Div>, <fes:Function>, <fes:Literal>, <fes:Mul>, "
+        "<fes:Sub>, <fes:ValueReference>."
     )
 
 

--- a/tests/gisserver/parsers/wfs20/test_requests.py
+++ b/tests/gisserver/parsers/wfs20/test_requests.py
@@ -43,11 +43,13 @@ class TestListStoredQueries:
         xml = '<ns0:ListStoredQueries version="2.0.0" service="WFS" xmlns:ns0="http://example.org/gisserver"></ns0:ListStoredQueries>'
         with pytest.raises(ExternalParsingError) as exc_info:
             parse_post_request(xml)
-        assert exc_info.value.args[0].startswith(
-            "Unsupported tag: <{http://example.org/gisserver}ListStoredQueries>,"
-            " expected one of: {http://www.opengis.net/wfs/2.0}GetCapabilities,"
-            " {http://www.opengis.net/wfs/2.0}DescribeFeatureType, "
-        )
+
+        message = exc_info.value.args[0]
+        assert message.startswith(
+            "Unsupported tag: <ns0:ListStoredQueries>,"
+            " expected one of: <{http://www.opengis.net/wfs/2.0}GetCapabilities>,"
+            " <{http://www.opengis.net/wfs/2.0}DescribeFeatureType>, "
+        ), message
 
 
 class TestGetCapabilities:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,6 +60,18 @@ def read_response(response: HttpResponseBase) -> str:
     return b"".join(response).decode()
 
 
+def read_partial_response(response: HttpResponseBase) -> tuple[str, Exception]:
+    """Read a response, allow it to be interrupted by an exception."""
+    content_parts = []
+    try:
+        for part in response:
+            content_parts.append(part)
+    except Exception as exc:
+        return b"".join(content_parts).decode(), exc
+    else:
+        return b"".join(content_parts).decode(), None
+
+
 def read_json(content) -> dict:
     try:
         return orjson.loads(content)


### PR DESCRIPTION
Trying a few filtering options in QGis. When trying `datefield > 2020-03-01` (without quotes) it completely broke error handling and parsing, as it was submitted as a filter for `datefield > ((2020 - 3) - 1)`. This addresses that, and adds more safeguards against bad input.