### PR TITLE
Add compatibility longitute/latitude rendering for old CRS notations

### DIFF
--- a/docs/compliance.rst
+++ b/docs/compliance.rst
@@ -61,6 +61,9 @@ Compatibility with older WFS-clients
 Some popular WFS-clients still use aspects of the WFS 1.0 filter syntax in their queries.
 To support these clients, the following logic is also implemented:
 
+Filter Logic
+............
+
 * The ``<PropertyName>`` tag instead of ``<fes:ValueReference>``
 * The ``<fes:Add>``, ``<fes:Sub>``, ``<fes:Mul>`` and ``<fes:Div>`` arithmetic operators, used by QGis.
 * The ``FILTER=<Filter>...</Filter>`` parameter without an XML namespace declaration, typically seen in web-browser libraries.
@@ -68,11 +71,33 @@ To support these clients, the following logic is also implemented:
 * The ``TYPENAME`` parameter instead of ``TYPENAMES`` (used by the CITE test suite!).
 * Using ``A`` and ``D`` as sort direction in ``SORTBY`` / ``<fes:SortBy>`` instead of ``ASC`` and ``DESC``.
 
+Coordinate Transformations
+..........................
+
+When an old syntax for coordinate transformation is used,
+the output will be rendered in legacy longitude/latitude ordering.
+It's mostly old JavaScript-based clients that use this.
+
+This can be disabled with the :ref:`GISSERVER_FORCE_XY_EPSG_4326` settings.
+
+When enabled, this applies to the ``SRSNAME=EPSG:4326`` parameter for projected output,
+and the ``BBOX=...`` parameter / ``<fes:BBOX>`` filter for coordinate input.
+
+The modern recommended notations ``urn:ogc:def:crs:EPSG::4326`` and ``http://www.opengis.net/def/crs/epsg/0/4326``,
+used by modern GIS-software, will always render in the proper latitude/longitude ordering.
+GeoJSON however, will always render in CRS84 longitude/latitude as the standard dictates.
+
+Content Types
+.............
+
 The FME (Feature Manipulation Engine) software sent ``OUTPUTFORMAT=application/gml+xml; version=3.2``
 to all methods, including ``GetCapabilities`` and ``DescribeFeatureType``. These are also silently accepted.
+
+CITE Testing
+............
 
 For CITE test suite compliance, ``urn:ogc:def:query:OGC-WFS::GetFeatureById`` query returns an HTTP 404
 for an invalid resource ID format, even though the WFS 2 specification states it should return
 an ``InvalidParameterValue``. Likewise, the ``<ResourceId>`` query returns an empty list instead
 of ``InvalidParameterValue`` for invalid resource ID formats.
-This behavior can be disabled with the ``GISSERVER_WFS_STRICT_STANDARD`` setting.
+This behavior can be disabled with the :ref:`GISSERVER_WFS_STRICT_STANDARD` setting.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -16,6 +16,8 @@ The defaults are:
     GISSERVER_COUNT_NUMBER_MATCHED = 1
 
     # Output rendering
+    GISSERVER_FORCE_XY_OLD_CRS = True
+    GISSERVER_FORCE_XY_EPSG_4326 = True
     GISSERVER_EXTRA_OUTPUT_FORMATS = {}
     GISSERVER_GET_FEATURE_OUTPUT_FORMATS = {}
 
@@ -73,6 +75,29 @@ Possible values:
 
 In the WFS output, ``number_matched="unknown"`` will be found when paging is disabled.
 
+.. _GISSERVER_FORCE_XY_EPSG_4326:
+.. _GISSERVER_FORCE_XY_OLD_CRS:
+
+GISSERVER_FORCE_XY\_...
+-----------------------
+
+By default, WFS 2.0 follows the axis ordering of the CRS authority.
+This means ``urn:ogc:def:crs:EPSG::4326`` will render in latitude/longitude ordering.
+
+For maximum interoperability with legacy web-clients,
+this behavior is relaxed by returning legacy longitude/latitude (screen x/y) ordering
+when legacy notations are used.
+
+* Using ``GISSERVER_FORCE_XY_EPSG_4326=True`` will force ``EPSG:4326`` into classic ordering.
+* Using ``GISSERVER_FORCE_XY_OLD_CRS=True`` will force :samp:`http://www.opengis.net/gml/srs/epsg.xml#{xxxx}` notations in classic ordering.
+
+Clients that use the OGC recommended notations, like ``urn:ogc:def:crs:EPSG::4326``
+and ``http://www.opengis.net/def/crs/epsg/0/4326`` always get the proper longitude/latitude.
+
+This does not affect GeoJSON output. The GeoJSON standard mandates that
+data is always returned in ``urn:ogc:def:crs:OGC::CRS84`` (which uses longitude/latitude ordering),
+to keep web-based clients simple.
+
 
 GISSERVER\_..._OUTPUT_FORMATS
 -----------------------------
@@ -104,6 +129,8 @@ paging unless the ``?COUNT=...`` request parameter is used.
     QGis often requests 1000 features per request, regardless of the maximum page size.
     Custom ``OutputRenderer`` subclasses may also override this setting.
 
+
+.. _GISSERVER_WFS_STRICT_STANDARD:
 
 GISSERVER_WFS_STRICT_STANDARD
 -----------------------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -5,6 +5,65 @@ While most errors should be self-explanatory,
 this page lists anything that might be puzzling.
 
 
+Latitude/longitude seem to be swapped
+-------------------------------------
+
+There is a lot to be said about `axis order confusion <https://wiki.osgeo.org/wiki/Axis_Order_Confusion>`_
+and the [differences between software](https://macwright.com/lonlat/).
+
+Basically, earlier geo-standards and software all assumed x/y-screen coordinates; implying longitude/latitude ordering.
+This conflicts with various safety-critical environments such as nautical, aerial and ground navigation
+that always worked in latitude/longitude. After a long debate, OGC and the WFS standard settled on using
+the axis ordering by the authority of the CRS (Coordinate Reference System).
+
+In practice this means:
+
+* PostGIS and libgeos uses legacy x/y notations, so data is longitude/latitude.
+* GeoJSON always always uses x/y notations for simplicity of web-based clients,
+  so longitude/latitude by enforcing the CRS ``urn:ogc:def:crs:OGC::CRS84``.
+* WFS 2.0, GDAL 3 and libproj follow the axis authority, so latitude/longitude.
+* Various legacy and web-based software still assumes the legacy notation.
+
+To handle a combination of legacy software, web-based clients, and modern systems
+we implemented the `GeoServer Axis Ordering <https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html>`_ guidelines:
+
+The following combinations of legacy formats trigger legacy handling:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Input
+     - Axis Order Interpretation
+   * - ``EPSG:4326`` + ``GISSERVER_FORCE_XY_EPSG_4326=True``
+     - Classic format for WGS84, using: longitude/latitude.
+   * - :samp:`http://www.opengis.net/gml/srs/epsg.xml#{code}` + ``GISSERVER_FORCE_XY_OLD_CRS=True``
+     - legacy format, always: longitude/latitude.
+
+These modern notations all follow the CRS authority:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Input
+     - Description
+   * - :samp:`EPSG:{code}`
+     - All EPSG notations, except EPSG:4326 above.
+   * - :samp:`urn:ogc:def:crs:EPSG:{code}`
+     - Modern URN format, follows CRS authority.
+   * - :samp:`http://www.opengis.net/def/crs/epsg/0/{code}`
+     - Modern URI format, follows CRS authority.
+
+It's worth noting that ``urn:ogc:def:crs:EPSG::4326`` and ``urn:ogc:def:crs:OGC::CRS84``
+are both defined as SRID 4326. However, CRS84 is defined as longitude/latitude axis
+and EPSG notation has a latitude/longitude axis.
+
+Since PostGIS uses GEOS, the raw data should be stored as longitude/latitude format.
+When the modern ``urn:ogc:def:crs:EPSG::4326`` projection is requested, the coordinates
+will be swapped during rendering.
+
+
 Operation on mixed SRID geometries
 ----------------------------------
 

--- a/gisserver/conf.py
+++ b/gisserver/conf.py
@@ -32,6 +32,17 @@ GISSERVER_COUNT_NUMBER_MATCHED = getattr(settings, "GISSERVER_COUNT_NUMBER_MATCH
 
 # -- output rendering
 
+# Following https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html here:
+# Whether the older EPSG:4326 notation (instead of the OGC recommended styles)
+# should render in legacy longitude/latitude (x/y) ordering.
+# This increases interoperability with legacy web clients,
+# as others use urn:ogc:def:crs:EPSG::4326 or http://www.opengis.net/def/crs/epsg/0/4326.
+GISSERVER_FORCE_XY_EPSG_4326 = getattr(settings, "GISSERVER_FORCE_XY_EPSG_4326", True)
+
+# Whether the legacy CRS notation http://www.opengis.net/gml/srs/epsg.xml# should render in X/Y
+GISSERVER_FORCE_XY_OLD_CRS = getattr(settings, "GISSERVER_FORCE_XY_OLD_CRS", True)
+
+# Extra output formats for GetFeature (see documentation for details)
 GISSERVER_EXTRA_OUTPUT_FORMATS = getattr(settings, "GISSERVER_EXTRA_OUTPUT_FORMATS", {})
 GISSERVER_GET_FEATURE_OUTPUT_FORMATS = getattr(
     settings, "GISSERVER_GET_FEATURE_OUTPUT_FORMATS", {}

--- a/gisserver/db.py
+++ b/gisserver/db.py
@@ -42,16 +42,22 @@ class AsGML(functions.AsGML):
         precision=conf.GISSERVER_DB_PRECISION,
         envelope=False,
         is_latlon=False,
+        long_urn=False,
         **extra,
     ):
         # Note that Django's AsGml the defaults are: version=2, precision=8
         super().__init__(expression, version, precision, **extra)
         self.envelope = envelope
         self.is_latlon = is_latlon
+        self.long_urn = long_urn
 
     def as_postgresql(self, compiler, connection, **extra_context):
         # Fill options parameter (https://postgis.net/docs/ST_AsGML.html)
-        options = 33 if self.envelope else 1  # 32 = bbox, 1 = long CRS urn
+        options = 0
+        if self.long_urn:
+            options |= 1  # long CRS urn
+        if self.envelope:
+            options |= 32  # bbox
         if self.is_latlon:
             # PostGIS provides the data in longitude/latitude format (east/north to look like x/y).
             # However, WFS 2.0 fixed their axis by following the authority. The ST_AsGML() doesn't

--- a/gisserver/parsers/gml/geometries.py
+++ b/gisserver/parsers/gml/geometries.py
@@ -89,7 +89,13 @@ class GEOSGMLGeometry(AbstractGeometry):
         # This avoids having to support the whole GEOS logic.
         geos_data = GEOSGeometry.from_gml(tostring(element))
         geos_data.srid = srs.srid
-        CRS.tag_geometry(geos_data, axis_order=AxisOrder.AUTHORITY)
+
+        # Using the WFS 2 format (urn:ogc:def:crs:EPSG::4326"), coordinates should be latitude/longitude.
+        # However, when providing legacy formats like srsName="EPSG:4326",
+        # input is assumed to be in legacy longitude/latitude axis ordering too.
+        # This reflects what GeoServer does: https://docs.geoserver.org/main/en/user/services/wfs/axis_order.html
+        if not srs.force_xy:
+            CRS.tag_geometry(geos_data, axis_order=AxisOrder.AUTHORITY)
         return cls(srs=srs, geos_data=geos_data)
 
     def __repr__(self):

--- a/gisserver/types.py
+++ b/gisserver/types.py
@@ -57,6 +57,7 @@ __all__ = [
     "GeometryXsdElement",
     "GmlIdAttribute",
     "GmlNameElement",
+    "GmlBoundedByElement",
     "ORMPath",
     "XPathMatch",
     "XsdAnyType",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ class CoordinateInputs:
     point1_ewkt: str
     point1_geojson: list[Decimal]
     point1_xml_wgs84: str
+    point1_xml_wgs84_legacy: str
     point1_xml_wgs84_bbox: str
     point1_xml_rd: str
 
@@ -159,6 +160,7 @@ def db_coordinates(django_db_setup, django_db_blocker):
             f" ST_AsGeoJson({point1_wgs84}, {pr}) as point1_geojson,"
             f" ST_AsGeoJson({point1_translated}, {pr}) as translated_geojson,"
             f" ST_AsGML(3, {point1_wgs84}, {pr}, 17) as point1_xml_wgs84,"
+            f" ST_AsGML(3, {point1_wgs84}, {pr}, 1) as point1_xml_wgs84_legacy,"
             f" ST_AsGML(3, {point1_wgs84}, {pr}, 1) as point1_xml_wgs84_bbox,"
             f" ST_AsGML(3, {point1_translated}, {pr}, 17) as translated_xml_wgs84,"
             f" ST_AsGML(3, ST_Union({point1_wgs84}, {point1_translated}), {pr}, 49) as translated_xml_envelope,"
@@ -183,6 +185,7 @@ def db_coordinates(django_db_setup, django_db_blocker):
             point1_ewkt=result["point1_ewkt"],
             point1_geojson=_get_geojson_coordinates(result["point1_geojson"]),
             point1_xml_wgs84=_get_gml_coordinates(result["point1_xml_wgs84"]),
+            point1_xml_wgs84_legacy=_get_gml_coordinates(result["point1_xml_wgs84_legacy"]),
             point1_xml_wgs84_bbox=_get_gml_coordinates(result["point1_xml_wgs84_bbox"]),
             point1_xml_rd=_get_gml_coordinates(result["point1_xml_rd"]),
             translated_wgs84=_get_point(result["translated_wgs84"]),
@@ -214,6 +217,7 @@ def python_coordinates(db_coordinates):
         point1_ewkt=flipped_point1_wgs84.ewkt,
         point1_geojson=_get_geojson_coordinates(db_coordinates.point1_wgs84.json),
         point1_xml_wgs84=_get_coordinates_text(flipped_point1_wgs84),
+        point1_xml_wgs84_legacy=_get_coordinates_text(db_coordinates.point1_wgs84),
         point1_xml_wgs84_bbox=_get_coordinates_text(db_coordinates.point1_wgs84),
         point1_xml_rd=_get_coordinates_text(point1_rd_back),
         translated_wgs84=flipped_translated_wgs84,  # How data from PointField is returned

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,7 +338,8 @@ def response(client, request) -> HttpResponseBase | Callable[..., HttpResponseBa
             ...
     """
     req: Request = request.param
-    response = req.get_response(client)
+    response = req.get_response(client)  # lambda or Django HTTP response
+    response.params = req
     response.expect = req.expect
     return response
 

--- a/tests/gisserver/test_crs.py
+++ b/tests/gisserver/test_crs.py
@@ -6,9 +6,62 @@ from gisserver.crs import CRS, WGS84
 
 
 class TestCRS:
-    def test_from_string(self):
-        assert CRS.from_string(4326).urn == "urn:ogc:def:crs:EPSG::4326"
-        assert CRS.from_string("EPSG:4326").urn == "urn:ogc:def:crs:EPSG::4326"
+    @pytest.mark.parametrize("input", [4326, "4326"])
+    def test_from_srid(self, input):
+        """Provide that the from_srid() uses modern notation"""
+        crs = CRS.from_string(input)
+        assert crs.origin is None
+        assert not crs.force_xy
+        assert crs.is_north_east_order
+        assert str(crs) == "urn:ogc:def:crs:EPSG::4326"
+
+    def test_from_string_modern(self):
+        """Prove that modern notation works."""
+        crs = CRS.from_string("urn:ogc:def:crs:EPSG::4326")
+        assert crs.origin == "urn:ogc:def:crs:EPSG::4326"
+        assert not crs.force_xy
+        assert crs.axis_direction == ["north", "east"]
+        assert crs.is_north_east_order
+
+        # Test output formats
+        assert crs.urn == "urn:ogc:def:crs:EPSG::4326"
+        assert crs.legacy == "http://www.opengis.net/gml/srs/epsg.xml#4326"
+        assert str(crs) == "urn:ogc:def:crs:EPSG::4326"
+
+    @pytest.mark.parametrize(
+        "force_xy,expect_str",
+        [
+            (False, "urn:ogc:def:crs:EPSG::4326"),
+            (True, "http://www.opengis.net/gml/srs/epsg.xml#4326"),
+        ],
+        ids=["modern", "force_xy"],
+    )
+    def test_from_string_legacy_epsg(self, force_xy, settings, expect_str):
+        """Prove that legacy notation has a legacy axis orientation by default."""
+        settings.GISSERVER_FORCE_XY_OLD_CRS = force_xy
+        settings.GISSERVER_FORCE_XY_EPSG_4326 = force_xy
+
+        legacy = CRS.from_string("epsg:4326")
+        assert legacy.origin == "EPSG:4326"
+        assert legacy.force_xy == force_xy
+        assert legacy.is_north_east_order  # not changed
+
+        # Test output formats
+        assert legacy.urn == "urn:ogc:def:crs:EPSG::4326"
+        assert legacy.legacy == "http://www.opengis.net/gml/srs/epsg.xml#4326"
+        assert str(legacy) == expect_str
+
+    def test_from_string_legacy_uri(self, settings):
+        settings.GISSERVER_FORCE_XY_EPSG_4326 = True
+        legacy = CRS.from_string("epsg:4326")
+        assert legacy.origin == "EPSG:4326"
+        assert legacy.force_xy
+        assert legacy.is_north_east_order  # not changed.
+
+        # Test output formats
+        assert legacy.urn == "urn:ogc:def:crs:EPSG::4326"
+        assert legacy.legacy == "http://www.opengis.net/gml/srs/epsg.xml#4326"
+        assert str(legacy) == "http://www.opengis.net/gml/srs/epsg.xml#4326"
 
     def test_crs84_inequal(self):
         """Prove that using strings from other vendors is also parsed."""
@@ -22,11 +75,29 @@ class TestCRS:
         """Prove that empty versions are properly re-encoded as empty string"""
         assert CRS.from_string("urn:ogc:def:crs:EPSG::28992").urn == "urn:ogc:def:crs:EPSG::28992"
 
-    def test_crs_url(self):
-        assert (
-            CRS.from_string("http://www.opengis.net/def/crs/epsg/0/4326").urn
-            == "urn:ogc:def:crs:EPSG::4326"
-        )
+    @pytest.mark.parametrize(
+        "modern_name", ["http://www.opengis.net/def/crs/epsg/0/4326", "urn:ogc:def:crs:EPSG::4326"]
+    )
+    @pytest.mark.parametrize("force_xy", [False, True], ids=["modern", "force_xy"])
+    def test_legacy_to_modern_url(self, modern_name, settings, force_xy):
+        settings.GISSERVER_FORCE_XY_OLD_CRS = force_xy
+        settings.GISSERVER_FORCE_XY_EPSG_4326 = force_xy
+
+        legacy_crs = CRS.from_string("EPSG:4326")
+        modern_crs = CRS.from_string(modern_name)
+        assert not modern_crs.force_xy
+
+        if force_xy:
+            # Resulting axes are different, so don't see is identical.
+            assert legacy_crs.force_xy
+            assert legacy_crs != modern_crs
+        else:
+            # Same output, treat is identical
+            assert not legacy_crs.force_xy
+            assert legacy_crs == modern_crs
+
+        assert legacy_crs.srid == modern_crs.srid
+        assert legacy_crs.urn == modern_crs.urn == "urn:ogc:def:crs:EPSG::4326"
 
     def test_axis_order_custom(self):
         """Prove that custom axis ordering is applied."""
@@ -57,18 +128,39 @@ class TestCRS:
         wgs84_point2 = WGS84.apply_to(wgs84_point, clone=True)
         assert wgs84_point == wgs84_point2
 
-    def test_axis_order_crs(self):
+    def test_axis_order_crs(self, settings):
         rd_point = Point(121400, 487400, srid=28992)
 
         # https://epsg.io/4326
-        wgs84_point = CRS.from_string("EPSG:4326").apply_to(rd_point, clone=True)
+        wgs84 = CRS.from_string("urn:ogc:def:crs:EPSG::4326")
+        assert wgs84.is_north_east_order
+        wgs84_point = wgs84.apply_to(rd_point, clone=True)
         assert round(wgs84_point.x, 6) == 52.373446  # 52 first
         assert round(wgs84_point.y, 6) == 4.893804
 
-        # For CRS84, which GeoJSON uses
-        crs84_point = CRS.from_string("urn:ogc:def:crs:OGC::CRS84").apply_to(rd_point, clone=True)
+        # For CRS84 its always longitude/latitude, which GeoJSON uses
+        crs84 = CRS.from_string("urn:ogc:def:crs:OGC::CRS84")
+        assert not crs84.is_north_east_order
+        crs84_point = crs84.apply_to(rd_point, clone=True)
         assert round(crs84_point.x, 6) == 4.893804  # 4 first
         assert round(crs84_point.y, 6) == 52.373446
+
+    @pytest.mark.parametrize("force_xy", [False, True], ids=["modern", "force_xy"])
+    def test_axis_order_legacy(self, settings, force_xy):
+        """Prove that legacy ordering is applied when a legacy notation is used."""
+        settings.GISSERVER_FORCE_XY_EPSG_4326 = force_xy
+
+        rd_point = Point(121400, 487400, srid=28992)
+
+        # Legacy intput, legacy conversion
+        wgs84_point = CRS.from_string("EPSG:4326").apply_to(rd_point, clone=True)
+
+        if force_xy:
+            assert round(wgs84_point.x, 6) == 4.893804
+            assert round(wgs84_point.y, 6) == 52.373446
+        else:
+            assert round(wgs84_point.x, 6) == 52.373446
+            assert round(wgs84_point.y, 6) == 4.893804
 
     def test_axis_order_finland(self):
         wgs84_point = Point(19.08, 58.84, srid=WGS84.srid)  # in PostGIS storage ordering

--- a/tests/gisserver/views/input.py
+++ b/tests/gisserver/views/input.py
@@ -185,6 +185,38 @@ FILTERS = [
         </fes:Filter>""",
     ),
     (
+        "bbox_crs84",
+        Url.NORMAL,
+        """
+        <fes:Filter
+            xmlns:wfs="http://www.opengis.net/wfs/2.0"
+            xmlns:fes="http://www.opengis.net/fes/2.0">
+            <fes:BBOX>
+                <gml:Envelope xmlns:gml="http://www.opengis.net/gml/3.2"
+                              srsName="urn:ogc:def:crs:OGC::CRS84">
+                    <gml:lowerCorner>4.908747234134033 52.36308132956971</gml:lowerCorner>
+                    <gml:upperCorner>4.908774657180266 52.36326119473073</gml:upperCorner>
+                </gml:Envelope>
+            </fes:BBOX>
+        </fes:Filter>""",
+    ),
+    (
+        "bbox_epsg_old",
+        Url.NORMAL,
+        """
+        <fes:Filter
+            xmlns:wfs="http://www.opengis.net/wfs/2.0"
+            xmlns:fes="http://www.opengis.net/fes/2.0">
+            <fes:BBOX>
+                <gml:Envelope xmlns:gml="http://www.opengis.net/gml/3.2"
+                              srsName="EPSG:4326">
+                    <gml:lowerCorner>4.908747234134033 52.36308132956971</gml:lowerCorner>
+                    <gml:upperCorner>4.908774657180266 52.36326119473073</gml:upperCorner>
+                </gml:Envelope>
+            </fes:BBOX>
+        </fes:Filter>""",
+    ),
+    (
         "and",
         Url.NORMAL,
         """

--- a/tests/gisserver/views/test_getcapabilities.py
+++ b/tests/gisserver/views/test_getcapabilities.py
@@ -73,6 +73,7 @@ class TestGetCapabilities:
         </ows:Keywords>
         <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
         <OtherCRS>urn:ogc:def:crs:EPSG::28992</OtherCRS>
+        <OtherCRS>urn:ogc:def:crs:OGC::CRS84</OtherCRS>
         <OutputFormats>
           <Format>application/gml+xml; version=3.2</Format>
           <Format>text/xml; subtype=gml/3.2.1</Format>

--- a/tests/gisserver/views/test_getfeature_gml.py
+++ b/tests/gisserver/views/test_getfeature_gml.py
@@ -513,19 +513,33 @@ class TestGetFeature:
 
     @parametrize_response(
         Get(
-            "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=restaurant"
-            "&SRSNAME=urn:ogc:def:crs:EPSG::28992"
+            lambda srs_name: "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=restaurant"
+            f"&SRSNAME={srs_name}"
         ),
         Post(
-            f"""<GetFeature service="WFS" version="2.0.0" {XML_NS}>
-              <Query typeNames="restaurant" srsName="urn:ogc:def:crs:EPSG::28992">
-              </Query>
+            lambda srs_name: f"""<GetFeature service="WFS" version="2.0.0" {XML_NS}>
+              <Query typeNames="restaurant" srsName="{srs_name}"></Query>
               </GetFeature>
               """
         ),
     )
-    def test_get_srs_name(self, restaurant, coordinates, response):
+    @pytest.mark.parametrize(
+        "srs_name",
+        [
+            "urn:ogc:def:crs:EPSG::28992",
+            "urn:ogc:def:crs:EPSG::4326",
+            "urn:ogc:def:crs:OGC::CRS84",
+        ],
+    )
+    def test_get_srs_name(self, restaurant, coordinates, response, srs_name):
         """Prove that specifying SRSNAME works"""
+        expect_xml_point = {
+            "urn:ogc:def:crs:EPSG::28992": coordinates.point1_xml_rd,
+            "urn:ogc:def:crs:EPSG::4326": coordinates.point1_xml_wgs84,
+            "urn:ogc:def:crs:OGC::CRS84": coordinates.point1_xml_wgs84_legacy,
+        }[srs_name]
+
+        response = response(srs_name)
         content = read_response(response)
         assert response["content-type"] == "text/xml; charset=utf-8", content
         assert response.status_code == 200, content
@@ -539,7 +553,7 @@ class TestGetFeature:
         # Prove that the output is now rendered in EPSG:28992
         feature = xml_doc.find("wfs:member/app:restaurant", namespaces=NAMESPACES)
         geometry = feature.find("app:location/gml:Point", namespaces=NAMESPACES)
-        assert geometry.attrib["srsName"] == "urn:ogc:def:crs:EPSG::28992"
+        assert geometry.attrib["srsName"] == srs_name
 
         timestamp = xml_doc.attrib["timeStamp"]
         assert_xml_equal(
@@ -556,17 +570,111 @@ class TestGetFeature:
           <app:restaurant gml:id="restaurant.{restaurant.id}">
             <gml:name>Café Noir</gml:name>
             <gml:boundedBy>
-              <gml:Envelope srsDimension="2" srsName="urn:ogc:def:crs:EPSG::28992">
-                <gml:lowerCorner>{coordinates.point1_xml_rd}</gml:lowerCorner>
-                <gml:upperCorner>{coordinates.point1_xml_rd}</gml:upperCorner>
+              <gml:Envelope srsDimension="2" srsName="{srs_name}">
+                <gml:lowerCorner>{expect_xml_point}</gml:lowerCorner>
+                <gml:upperCorner>{expect_xml_point}</gml:upperCorner>
               </gml:Envelope>
             </gml:boundedBy>
             <app:id>{restaurant.id}</app:id>
             <app:name>Café Noir</app:name>
             <app:city_id>{restaurant.city_id}</app:city_id>
             <app:location>
-              <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="urn:ogc:def:crs:EPSG::28992">
-                <gml:pos srsDimension="2">{coordinates.point1_xml_rd}</gml:pos>
+              <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="{srs_name}">
+                <gml:pos srsDimension="2">{expect_xml_point}</gml:pos>
+              </gml:Point>
+            </app:location>
+            <app:rating>5.0</app:rating>
+            <app:is_open>true</app:is_open>
+            <app:created>2020-04-05T12:11:10+00:00</app:created>
+            <app:tags>cafe</app:tags>
+            <app:tags>black</app:tags>
+          </app:restaurant>
+        </wfs:member>
+    </wfs:FeatureCollection>""",  # noqa: E501
+        )
+
+    @parametrize_response(
+        Get(
+            lambda srs_name: "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=restaurant"
+            f"&SRSNAME={srs_name}"
+        ),
+        Post(
+            lambda srs_name: f"""<GetFeature service="WFS" version="2.0.0" {XML_NS}>
+              <Query typeNames="restaurant" srsName="{srs_name}"></Query>
+            </GetFeature>
+            """
+        ),
+    )
+    @pytest.mark.parametrize(
+        "srs_name", ["http://www.opengis.net/gml/srs/epsg.xml#4326", "EPSG:4326"]
+    )
+    @pytest.mark.parametrize("force_xy", [False, True], ids=["modern", "force_xy"])
+    def test_get_srs_name_legacy(
+        self, restaurant, coordinates, response, settings, force_xy, srs_name
+    ):
+        """Prove that specifying a legacy SRSNAME will render coordinates in their legacy notation"""
+        settings.GISSERVER_FORCE_XY_OLD_CRS = force_xy
+        settings.GISSERVER_FORCE_XY_EPSG_4326 = force_xy
+        if force_xy:
+            # Let legacy input stay legacy output
+            expect_srs_name = "http://www.opengis.net/gml/srs/epsg.xml#4326"
+            expect_point = coordinates.point1_xml_wgs84_legacy
+            comment = f"""<!--
+ NOTE: you are requesting the legacy projection notation '{srs_name}'. Please use 'urn:ogc:def:crs:EPSG::4326' instead.
+ This also means output coordinates are ordered in legacy the 'west, north' axis ordering.
+
+-->"""  # noqa: E501
+        else:
+            # Let legacy input become regular WFS 2.0 output
+            expect_srs_name = "urn:ogc:def:crs:EPSG::4326"
+            expect_point = coordinates.point1_xml_wgs84
+            comment = ""
+
+        # perform request after settings have been updated.
+        response = response(
+            srs_name.replace("#", "%23") if response.params.method == "GET" else srs_name
+        )
+        content = read_response(response)
+        assert response["content-type"] == "text/xml; charset=utf-8", content
+        assert response.status_code == 200, content
+        assert "</wfs:FeatureCollection>" in content
+
+        # Validate against the WFS 2.0 XSD
+        xml_doc = validate_xsd(content, WFS_20_XSD)
+        assert xml_doc.attrib["numberMatched"] == "1"
+        assert xml_doc.attrib["numberReturned"] == "1"
+
+        # Prove that the output is now rendered in srid 4326
+        feature = xml_doc.find("wfs:member/app:restaurant", namespaces=NAMESPACES)
+        geometry = feature.find("app:location/gml:Point", namespaces=NAMESPACES)
+        assert geometry.attrib["srsName"] == expect_srs_name
+
+        timestamp = xml_doc.attrib["timeStamp"]
+        assert_xml_equal(
+            content,
+            f"""<wfs:FeatureCollection
+       xmlns:app="http://example.org/gisserver"
+       xmlns:gml="http://www.opengis.net/gml/3.2"
+       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://example.org/gisserver http://testserver/v1/wfs/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAMES=app:restaurant http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+       timeStamp="{timestamp}" numberMatched="1" numberReturned="1">
+        {comment}
+        <wfs:member>
+          <app:restaurant gml:id="restaurant.{restaurant.id}">
+            <gml:name>Café Noir</gml:name>
+            <gml:boundedBy>
+              <gml:Envelope srsDimension="2" srsName="{expect_srs_name}">
+                <gml:lowerCorner>{expect_point}</gml:lowerCorner>
+                <gml:upperCorner>{expect_point}</gml:upperCorner>
+              </gml:Envelope>
+            </gml:boundedBy>
+            <app:id>{restaurant.id}</app:id>
+            <app:name>Café Noir</app:name>
+            <app:city_id>{restaurant.city_id}</app:city_id>
+            <app:location>
+              <gml:Point gml:id="Restaurant.{restaurant.id}.1" srsName="{expect_srs_name}">
+                <gml:pos srsDimension="2">{expect_point}</gml:pos>
               </gml:Point>
             </app:location>
             <app:rating>5.0</app:rating>

--- a/tests/requests.py
+++ b/tests/requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable
+from typing import Any, Callable, ClassVar
 
 import pytest
 from django.test import Client
@@ -50,6 +50,7 @@ class Request:
 
 @dataclass
 class Get(Request):
+    method: ClassVar[str] = "GET"
     query: str | Callable
 
     def __init__(self, query, **kwargs):
@@ -82,6 +83,7 @@ class Get(Request):
 
 @dataclass
 class Post(Request):
+    method: ClassVar[str] = "POST"
     body: str | Callable
     query: str | Callable | None
     validate_xml: bool
@@ -141,6 +143,9 @@ def parametrize_response(*param_values: Request, url: Url | None = None):
     Requests (Get, Post) either get a string query/body argument or a Callable, which can be used
     later in the testing function to perform different requests at different times in the test.
     In this case, you need to call the response() to get an actual response object in your test.
+
+    The ``response`` fixture also receives a ``params`` that references the original parameters,
+    and it will get an ``expect`` value when that is set.
 
     NB: When your response depends on other fixtures (for example because you need to have
     some rows in the database), ensure the `response` fixture argument comes at the end of the

--- a/tests/test_gisserver/views.py
+++ b/tests/test_gisserver/views.py
@@ -1,6 +1,7 @@
 import django
 from django.core.exceptions import PermissionDenied
 
+from gisserver.crs import CRS84
 from gisserver.features import FeatureType, ServiceDescription, field
 from gisserver.views import WFSView
 from tests.test_gisserver import models
@@ -30,7 +31,7 @@ class PlacesWFSView(WFSView):
             models.Restaurant.objects.all(),
             fields="__all__",  # includes 'tags' as array field, but no relations.
             keywords=["unittest"],
-            other_crs=[RD_NEW],
+            other_crs=[RD_NEW, CRS84],
             metadata_url="/feature/restaurants/",
         ),
         FeatureType(


### PR DESCRIPTION
This is inspired by [GeoServer axis order](https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html) to return old axis ordering for old CRS notations. The settings can be disabled too, and are completely documented and tested.